### PR TITLE
Match more main files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,7 +66,8 @@
       "fzx_assets.h": "c",
       "fzx_course.h": "c",
       "fzx_save.h": "c",
-      "fzx_math.h": "c"
+      "fzx_math.h": "c",
+      "ovl_i4.h": "c"
     },
     "C_Cpp_Runner.msvcBatchPath": "",
     "C_Cpp.errorSquiggles": "enabled"

--- a/include/functions.h
+++ b/include/functions.h
@@ -38,11 +38,18 @@ void Controller_Init(void);
 void Math_SinTableInit(void);
 void Math_Rand1Init(s32 seed, s32 mask);
 void Math_Rand2Init(s32 seed, s32 mask);
+u32 Math_Rand1(void);
+u32 Math_Rand2(void);
 s32 Math_Round(f32 num);
+Gfx* func_806F6360(Gfx*, s32);
+s32 func_806F6D8C(Mtx3F* mtx);
+s32 func_806F6F64(Mtx3F* mtx);
 void Matrix_ToMtx(MtxF* src, Mtx* dest2);
-void func_806F86C0(Mtx*, MtxF*, f32, s32, s32, s32, f32, f32, f32);
 void func_806F7FCC(Mtx*, MtxF*, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32);
+void func_806F86C0(Mtx*, MtxF*, f32, s32, s32, s32, f32, f32, f32);
 void func_806F8868(Mtx*, MtxF*, f32, s32, f32, f32, f32, f32, f32, f32);
+void func_806F8FE0(Mtx*, MtxF*, f32, f32, f32, f32, f32, f32, f32, f32, f32);
+void func_806F9384(Mtx*, MtxF*, f32, f32, f32, f32, f32, f32, f32, u16*);
 
 Gfx* func_806FC340(Gfx* gfx);
 Gfx* func_806FC3AC(Gfx* gfx);
@@ -77,6 +84,7 @@ s32 func_80703CA4(s32 startLba, void* vram, s32 diskSize, s32 bssSize);
 s32 func_80703E08(s32 startLba, void* vram, s32 diskSize, s32 bssSize);
 
 void func_80704050(s32);
+void func_8070481C(void);
 s32 func_8070595C(void);
 void SLForceWritebackDCacheAll(void);
 s32 SLLeoReadWrite(LEOCmd* cmdBlock, s32 direction, s32 lba, u8* vAddr, u32 nLbas, OSMesgQueue* mq);
@@ -84,6 +92,8 @@ s32 SLLeoReadWrite_DATA(LEOCmd* cmdBlock, s32 direction, s32 lba, u8* vAddr, u32
 void SLMFSRecoverManageArea(void);
 void func_80706518(s32, s32, s32);
 void SLMFSDeleteFile(u16, u8*, u8*, s32);
+s32 SLMFSCreateManager(s32 region);
+void SLLeoModeSelectAsync(u32 standby, u32 sleep);
 void SLMFSNewDisk(void);
 void SLMFSNewDisk2(void);
 s32 func_80707780(void);
@@ -140,13 +150,49 @@ void func_8070DAD4(s32);
 void func_8070DAFC(void);
 void func_8070DD88(void);
 void func_8070F0D0(void);
+
+void func_80715768(unk_struct_20_2*, s32);
+void func_80715E1C(Vec3f*, unk_struct_20_2*, unk_struct_14*);
+void func_80715E60(Vec3f*, unk_struct_20_2*, unk_struct_14*);
+void func_80715EC0(unk_80085434_arg_0*, unk_struct_20_2*, unk_80085434_arg_2*);
+void func_80715F20(unk_80085494_arg_0*, unk_struct_20_2*, unk_80085494_arg_2*);
+void func_807166B8(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_80716F38(Player* player);
+void func_80717354(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_807176B4(Player*, unk_struct_F8*);
+void func_80717B20(void);
+void func_807181F8(Player*, unk_struct_F8*);
+void func_80718530(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_80718908(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_80718964(Player*, unk_struct_F8*);
+void func_80718AB0(Player*, unk_struct_F8*);
+void func_80718AFC(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_80718F58(Vec3f*, CourseSegment*, f32, unk_800CD970*);
+void func_80719140(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_807191B0(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_80719420(Player*, unk_struct_F8*, unk_800E5D70*);
+void func_80719480(Player*, unk_struct_F8*, unk_800E5D70*);
+bool func_80719868(s32);
+
 void func_80715F9C(void);
 void func_8071ED34(void);
 
+
+void func_80740BD8(u8);
+void func_80741A0C(u8);
+void func_80741B84(void);
+void func_80741BCC(void);
+void func_80741CB4(u8);
+void func_80741DD4(void);
+void func_80741E64(void);
+void func_80742004(void);
+void func_807423F4(s32);
 s32 func_807424CC(void);
 s32 func_80742790(void);
 void func_8074279C(void);
 
+void func_80762330(LEODiskTime*);
+void func_80760F40(u8*, u8*);
 s32 func_80768B88(OSPiHandle*, OSIoMesg*, s32);
 u16 func_80766788(void);
 s32 func_80766660(u16);
@@ -160,7 +206,10 @@ Gfx* func_xk1_8002F9DC(Gfx*);
 void func_xk1_8002FFA0(void);
 void func_xk1_8002FFDC(void);
 
-s32 Save_UpdateCourseCharacterSave(s32);
+s32 Save_UpdateCourseCharacterSave(s32 courseIndex);
+s32 Save_SaveSettingsProfiles(void);
+s32 Save_LoadStaffGhostRecord(GhostInfo* ghostInfo, s32 courseIndex);
+
 void func_i2_800A20A0(void);
 Gfx* func_i2_800A2B0C(Gfx*);
 void func_i2_800A2CCC(void);

--- a/include/fzx_game.h
+++ b/include/fzx_game.h
@@ -102,12 +102,14 @@ typedef enum Character {
 } Character;
 
 typedef enum Cup {
-    JACK_CUP,
-    QUEEN_CUP,
-    KING_CUP,
-    JOKER_CUP,
-    X_CUP,
-    EDIT_CUP,
+    /* 0 */ JACK_CUP,
+    /* 1 */ QUEEN_CUP,
+    /* 2 */ KING_CUP,
+    /* 3 */ JOKER_CUP,
+    /* 4 */ X_CUP,
+    /* 5 */ EDIT_CUP,
+    /* 6 */ CUP_6,
+    /* 7 */ CUP_7,
 } Cup;
 
 #endif // FZX_GAME_H

--- a/include/sys.h
+++ b/include/sys.h
@@ -54,7 +54,13 @@ typedef union unk_Light {
 
 typedef struct GfxPool {
     Gfx gfxBuffer[1];
-    s8 pad_00008[0x36620];
+    s8 pad_00008[0x1A000];
+    Mtx unk_1A008[4];
+    Mtx unk_1A108[4];
+    Mtx unk_1A208[4];
+    s8 pad_1A308[0x1BFC0];
+    Vp unk_362C8[4];
+    s8 pad_36308[0x320];
     Mtx unk_36628[1];
     Mtx unk_36668[1];
     Mtx unk_366A8[1];

--- a/include/unk_structs.h
+++ b/include/unk_structs.h
@@ -486,4 +486,170 @@ typedef struct Racer {
     s32 unk_3A4;
 } Racer; // size = 0x3A8
 
+typedef struct RaceStats {
+    s32 raceTime;
+    f32 maxSpeed;
+    s16 position;
+    s16 unk_0A;
+    s16 racersKOd;
+    s8 unk_0E[0x2];
+} RaceStats; // size = 0x10
+
+typedef Gfx* (*unk_800E51B8_unk_1C_func)(Gfx*, s32, s32);
+
+typedef struct unk_800E51B8 {
+    s32 unk_00;
+    s16 unk_04;
+    s16 unk_06;
+    s16 unk_08;
+    s16 unk_0A;
+    s16 unk_0C;
+    s16 unk_0E;
+    s16 unk_10;
+    s16 unk_12;
+    s16 unk_14;
+    s16 unk_16;
+    u16 unk_18;
+    u16 unk_1A;
+    u16 unk_1C;
+    unk_800E51B8_unk_1C_func unk_20;
+} unk_800E51B8; // size = 0x20
+
+typedef struct unk_struct_20 {
+    Vec3f unk_00;
+    Vec3f unk_0C;
+    f32 unk_18;
+    f32 unk_1C;
+} unk_struct_20; // size = 0x20
+
+typedef struct unk_struct_54 {
+    unk_struct_20 unk_00;
+    f32 unk_20;
+    Vec3f unk_24;
+    Vec3f unk_30;
+    Vec3f unk_3C;
+    Vec3f unk_48;
+} unk_struct_54; // size = 0x54
+
+typedef struct unk_struct_68 {
+    unk_struct_54 unk_00;
+    Vec3f unk_54;
+    f32 unk_60;
+    f32 unk_64;
+} unk_struct_68; // size = 0x68
+
+typedef struct unk_struct_9C {
+    unk_struct_68 unk_00;
+    f32 unk_68[10];
+    f32 unk_90;
+    f32 unk_94;
+    s32 unk_98;
+} unk_struct_9C; // size = 0x9C
+
+typedef struct unk_struct_58 {
+    Vec3f unk_00;
+    Vec3f unk_0C;
+    f32 unk_18[16];
+} unk_struct_58; // size = 0x58
+
+typedef struct unk_redo_1 {
+    unk_struct_58 unk_00;
+    unk_struct_20 unk_58;
+} unk_redo_1; // size = 0x78
+
+typedef struct unk_redo_2 {
+    unk_struct_58 unk_00;
+    unk_struct_54 unk_58;
+} unk_redo_2; // size = 0xAC
+
+typedef struct unk_redo_3 {
+    unk_struct_58 unk_00;
+    unk_struct_68 unk_58;
+} unk_redo_3; // size = 0xC0
+
+typedef struct unk_8008112C_arg_1 {
+    unk_struct_58 unk_00;
+    unk_struct_9C unk_58;
+} unk_8008112C_arg_1; // size = 0xF4
+
+typedef struct unk_struct_F8 {
+    s32 unk_00;
+    unk_8008112C_arg_1 unk_04;
+} unk_struct_F8; // size = 0xF8
+
+typedef struct unk_struct_14 {
+    s32 unk_00;
+    f32* unk_04[3];
+    s32* unk_10;
+} unk_struct_14; // size = 0x14
+
+typedef struct unk_80085154_arg_2 {
+    s32 unk_00;
+    f32* unk_04;
+    s32* unk_08;
+} unk_80085154_arg_2; // size = 0xC
+
+typedef struct unk_80085434_arg_2 {
+    unk_struct_14 unk_00[2];
+    unk_80085154_arg_2 unk_28;
+} unk_80085434_arg_2; // size = 0x34
+
+typedef struct unk_80085494_arg_2 {
+    unk_struct_14 unk_00[3];
+    unk_80085154_arg_2 unk_3C;
+} unk_80085494_arg_2; // size = 0x48
+
+typedef struct unk_80085434_arg_0 {
+    Vec3f unk_00[2];
+    f32 unk_18;
+} unk_80085434_arg_0; // size = 0x1C
+
+typedef struct unk_80085494_arg_0 {
+    Vec3f unk_00[3];
+    f32 unk_24;
+} unk_80085494_arg_0; // size = 0x28
+
+typedef struct unk_struct_8 {
+    s32 unk_00;
+    s32 unk_04;
+} unk_struct_8; // size = 0x8
+
+typedef struct unk_struct_20_2 {
+    unk_struct_8 unk_00[4];
+} unk_struct_20_2; // size = 0x20
+
+typedef struct unk_struct_C {
+    s32 unk_00;
+    void* unk_04;
+    void* unk_08;
+} unk_struct_C; // size = 0xC
+
+typedef struct unk_800E5D70 {
+    unk_struct_F8* unk_00;
+    unk_struct_C* unk_04;
+    s32 unk_08;
+    unk_struct_20_2* unk_0C;
+    Vec3f* unk_10;
+    Mtx3F* unk_14;
+    Racer* unk_18;
+    Vec3f* unk_1C;
+    Mtx3F* unk_20;
+} unk_800E5D70; // size = 0x24
+
+typedef struct unk_800CD8B0 {
+    Vec3f unk_00;
+    Vec3f unk_0C;
+    Vec3f unk_18;
+    Vec3f unk_24;
+    f32 unk_30;
+    f32 unk_34;
+} unk_800CD8B0; // size 0x38
+
+typedef struct unk_800CD970 {
+    s16 unk_00;
+    s16 unk_02;
+    f32 unk_04;
+    f32* unk_08;
+} unk_800CD970; // size 0xC
+
 #endif // UNK_STRUCTS_H

--- a/linker_scripts/jp/symbol_addrs.txt
+++ b/linker_scripts/jp/symbol_addrs.txt
@@ -90,8 +90,16 @@ gRandMask1 = 0x8076C944;
 gRandSeed2 = 0x8076C948;
 gRandMask2 = 0x8076C94C;
 
+gSelectedMode = 0x8076CC50;
+gPlayerSelectionLock = 0x8076CC78;
+gMachineSelectState = 0x8076CC80;
+gMachineSettingsState = 0x8076CC84;
 gSettingEverythingUnlocked = 0x8076CC98;
 gCurrentGhostType = 0x8076CC9C;
+gUnlockableLevel = 0x8076CC90;
+gModeSubOption = 0x8076CC58;
+sTrackNames = 0x8076CCA4; // size:0xB0
+gMachineNames = 0x8076CD54;
 
 sLeoErrorMessages = 0x8076D344; // size:0x98
 sLeoFontPallete = 0x8076D4BC;
@@ -100,6 +108,8 @@ sFaultCharIndex = 0x8076D4E0;
 sFaultCharPixelFlags = 0x8076D560;
 sFaultCauses = 0x8076D660;
 sFloatExceptions = 0x8076D6A8;
+
+sMaxCameraLookBackRotate = 0x8076D8B4;
 
 gSettingVsHandicap = 0x8076E2F0;
 gSettingVsCom = 0x8076E2F4;
@@ -141,9 +151,19 @@ gControllersConnected = 0x8079A898;
 gSinTable = 0x8079A8A0; // size:0x4000
 
 gSegments = 0x8079FA40;
+
 gCharacterLastEngine = 0x8079FAA0;
+gInputPressed = 0x8079FB1C;
 gInputButtonPressed = 0x8079FB1E;
+gStickPressed = 0x8079FB20;
 gCupNumDifficultiesCleared = 0x8079FB24;
+gCurrentTrackName = 0x8079FB2C;
+gTrackNames = 0x8079FB30; // size:0xDC
+
+gSkyboxType = 0x8079FC10;
+gVenueType = 0x8079FC14;
+gCupRaceStats = 0x8079FC18; // size:0x60
+gRecordNameEntered = 0x8079FC78; // size:0x4
 
 sLeoPrintFrameBuffer = 0x8079FC80;
 sLeoPrintCurPixel = 0x8079FC84;
@@ -232,7 +252,7 @@ __osPfsDeclearPage = 0x80748FA4;
 osPfsFreeBlocks = 0x807490F0;
 __osProbeTLB = 0x80749290;
 __d_to_ll = 0x80749350;
-__f_to_ll = 0x80749368;
+__f_to_ll = 0x8074936C;
 __d_to_ull = 0x80749388;
 __f_to_ull = 0x80749428;
 __ll_to_d = 0x807494C4;
@@ -830,3 +850,18 @@ gCourseInfos = 0x802BB140; //segment:unk_context size:0x3480
 gRacers = 0x802D2F20; //segment:unk_context size:0x6DB0
 
 D_807794F0 = 0x807794F0; // force_migration:True
+
+D_807763D0 = 0x807763D0; // size:0x78
+D_80776448 = 0x80776448; // size:0xAC
+D_807764F4 = 0x807764F4; // size:0xF4
+D_807765E8 = 0x807765E8; // size:0xC0
+D_807766A8 = 0x807766A8; // size:0xAC
+D_80776754 = 0x80776754; // size:0xAC
+D_80776800 = 0x80776800; // size:0xAC
+D_807768AC = 0x807768AC; // size:0x78
+D_80776924 = 0x80776924; // size:0x78
+D_8077699C = 0x8077699C; // size:0xAC
+D_80776A48 = 0x80776A48; // size:0x30
+D_80776A78 = 0x80776A78; // size:0x30
+D_80776AA8 = 0x80776AA8; // size:0xF4
+D_80776B9C = 0x80776B9C; // size:0xF4

--- a/linker_scripts/jp/symbol_addrs_overlays.txt
+++ b/linker_scripts/jp/symbol_addrs_overlays.txt
@@ -2,6 +2,8 @@ func_i3_8003F2E0 = 0x8003F2E0; //segment:ovl_i3
 func_i3_80059EC0 = 0x80059EC0; //segment:ovl_i3
 func_i3_ResetLivesChangeCounter = 0x8005F6A8; //segment:ovl_i3
 
+gFastestGhostTime = 0x8006D450; //segment:ovl_i3
+
 Save_ReadGhostRecord = 0x800A5D40; //segment:ovl_i2
 Save_ReadGhostData = 0x800A5D7C; //segment:ovl_i2
 Save_ReadCharacterSave = 0x800A5DB8; //segment:ovl_i2

--- a/src/10AB0.c
+++ b/src/10AB0.c
@@ -1,3 +1,5 @@
-#include "common.h"
+#include "global.h"
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10AB0/func_807032B0.s")
+f32 func_807032B0(Vec3f arg0, Vec3f arg1) {
+    return sqrtf(SQ(arg1.x - arg0.x) + SQ(arg1.y - arg0.y) + SQ(arg1.z - arg0.z));
+}

--- a/src/10B20.c
+++ b/src/10B20.c
@@ -1,13 +1,106 @@
-#include "common.h"
+#include "global.h"
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10B20/func_80703320.s")
+void func_80703320(f32* arg0, f32* arg1) {
+    f32 temp_fa0;
+    f32 temp_fv1;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10B20/func_807033A0.s")
+    temp_fa0 = SQ(*arg0) + SQ(*arg1);
+    if (temp_fa0 < 1e-07) {
+        return;
+    }
+    temp_fv1 = 1.0f / sqrtf(temp_fa0);
+    *arg0 *= temp_fv1;
+    *arg1 *= temp_fv1;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10B20/func_80703444.s")
+void func_807033A0(f32* arg0, f32* arg1, f32* arg2) {
+    f32 temp_fa1;
+    f32 temp_fv1;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10B20/func_807034F0.s")
+    temp_fa1 = SQ(*arg0) + SQ(*arg1) + SQ(*arg2);
+    if (temp_fa1 < 1e-07) {
+        return;
+    }
+    temp_fv1 = 1.0f / sqrtf(temp_fa1);
+    *arg0 *= temp_fv1;
+    *arg1 *= temp_fv1;
+    *arg2 *= temp_fv1;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10B20/func_807037A4.s")
+s32 func_80703444(Vec3f* arg0, f32 arg1) {
+    f32 temp_fa1;
+    f32 temp_fv1;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/10B20/D_80773A10.s")
+    temp_fa1 = SQ(arg0->x) + SQ(arg0->y) + SQ(arg0->z);
+    if (temp_fa1 < 1e-07) {
+        return -1;
+    }
+    temp_fv1 = arg1 / sqrtf(temp_fa1);
+    arg0->x *= temp_fv1;
+    arg0->y *= temp_fv1;
+    arg0->z *= temp_fv1;
+    return 0;
+}
+
+extern CourseContext gCourseCtx;
+
+void func_807034F0(CourseInfo* arg0) {
+    s32 pad[4];
+    f32 spF4;
+    f32 spF0;
+    f32 spEC;
+    f32 spE8;
+    f32 spE4;
+    f32 spE0;
+    Vec3f spD4;
+    MtxF sp94;
+    s32 i;
+    CourseSegment* var_s0;
+
+    var_s0 = arg0->courseSegments;
+    for (i = 0; i < arg0->segmentCount; i++) {
+        func_i2_800B2500(var_s0, 0.0f, &spD4);
+        func_80703444(&spD4, 1);
+        if ((SQ(spD4.x) + SQ(spD4.z)) != 0.0f) {
+            spE8 = spD4.z;
+            spE4 = 0.0f;
+            spE0 = -1.0f * spD4.x;
+        } else {
+            spE8 = 0.0f;
+            spE4 = 0.0f;
+            spE0 = spD4.y;
+        }
+
+        func_807033A0(&spE8, &spE4, &spE0);
+        spF4 = ((spE4 * spD4.z) - (spE0 * spD4.y)) * -1.0f;
+        spF0 = ((spE0 * spD4.x) - (spE8 * spD4.z)) * -1.0f;
+        spEC = ((spE8 * spD4.y) - (spE4 * spD4.x)) * -1.0f;
+        func_807033A0(&spF4, &spF0, &spEC);
+        func_806F8868(NULL, &sp94, 1.0f, DEG_TO_FZXANG(gCourseCtx.courseData.bankAngle[i]), spD4.x, spD4.y, spD4.z,
+                      0.0f, 0.0f, 0.0f);
+        var_s0->unk_0C.x = sp94.m[0][0] * spF4 + sp94.m[1][0] * spF0 + sp94.m[2][0] * spEC;
+        var_s0->unk_0C.y = sp94.m[0][1] * spF4 + sp94.m[1][1] * spF0 + sp94.m[2][1] * spEC;
+        var_s0->unk_0C.z = sp94.m[0][2] * spF4 + sp94.m[1][2] * spF0 + sp94.m[2][2] * spEC;
+        var_s0 = var_s0->next;
+    }
+}
+
+void func_807037A4(void) {
+    f32 sp2C;
+    s64 temp;
+    bcmp(NULL, NULL, 0);
+    osEPiReadIo(NULL, 0, NULL);
+    osEPiWriteIo(NULL, 0, 0);
+    __osSetHWIntrRoutine(0, NULL, NULL);
+    osStopThread(NULL);
+    osGetIntMask();
+    osEPiLinkHandle(NULL);
+    osPfsInitPak(NULL, NULL, 0);
+    osPfsAllocateFile(NULL, 0, 0, NULL, NULL, 0, NULL);
+    osPfsReadWriteFile(NULL, 0, 0, 0, 0, NULL);
+    osPfsFindFile(NULL, 0, 0, NULL, NULL, NULL);
+    __osSetCause(0);
+    __osSetCount(0);
+    sprintf(NULL, "\0\0\0\0\0\0\0");
+    temp = sp2C;
+}

--- a/src/17490.c
+++ b/src/17490.c
@@ -1,239 +1,1071 @@
-#include "common.h"
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_80709C90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_80709DEC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A078.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A3D8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A3F4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A498.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A594.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A6C0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A6DC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A790.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A844.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A8F8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070A99C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070C600.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070D220.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070D358.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/Controller_SetGlobalInputs.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070D4A8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070D858.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070D870.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DA54.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DA84.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DAA4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DAD4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DAFC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DB48.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DB94.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DBE0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DBF0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DC94.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DD88.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DE6C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070DEE0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070E79C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070EA38.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070EB3C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070EB90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/func_8070EC64.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_807759E0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_807759EC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_807759F4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A00.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A10.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A1C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A28.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A34.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A40.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A54.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A60.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A6C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A78.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A84.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775A9C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775AAC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775ABC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775AC8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775AD8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775AEC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775AF8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B08.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B14.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B20.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B28.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B30.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B38.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B40.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B48.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B50.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B54.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B58.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B64.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B74.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B88.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775B94.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BA8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BB4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BC0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BD0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BDC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BEC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775BFC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C08.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C14.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C20.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C2C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C3C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C48.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C54.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C60.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C6C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C78.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C88.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775C98.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775CAC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775CBC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775CCC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775CDC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775CE8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775CF4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D00.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D0C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D1C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D28.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D38.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D48.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D54.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D64.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D70.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D80.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D8C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775D9C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DA8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DB8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DC4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DD0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DE0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DEC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/17490/D_80775DF8.s")
+#include "global.h"
+#include "fzx_game.h"
+#include "fzx_assets.h"
+#include "src/overlays/ovl_i4/ovl_i4.h"
+
+f32 gCharacterLastEngine[30];
+UNUSED s32 D_8079FB18;
+u16 gInputPressed;
+u16 gInputButtonPressed;
+u16 gStickPressed;
+s8 gCupNumDifficultiesCleared[4];
+s8 D_8079FB28[2];
+char* gCurrentTrackName;
+char* gTrackNames[55];
+
+s32 gSelectedMode = MODE_GP_RACE;
+UNUSED s32 D_8076CC54 = 0;
+s32 gModeSubOption[8] = { 0 };
+s8 gPlayerSelectionLock[] = { SELECTION_FREE, SELECTION_FREE, SELECTION_FREE, SELECTION_FREE };
+s8 D_8076CC7C[] = { 1, 1, 1, 1 };
+s32 gMachineSelectState = MACHINE_SELECT_ACTIVE;
+s32 gMachineSettingsState = MACHINE_SETTINGS_ACTIVE;
+s32 D_8076CC88 = 0;
+s32 D_8076CC8C = 0;
+s8 gUnlockableLevel = 0;
+s8 D_8076CC94 = 0;
+s8 gSettingEverythingUnlocked = false;
+s32 gCurrentGhostType = GHOST_PLAYER;
+bool D_8076CCA0 = false;
+
+const char* sTrackNames[] = {
+    "mute city",
+    "silence",
+    "sand ocean",
+    "devil's forest",
+    "big blue",
+    "port town",
+    "sector Ａ",
+    "red canyon",
+    "devil's forest 2",
+    "mute city 2",
+    "big blue 2",
+    "white land",
+    "fire field",
+    "silence 2",
+    "sector Ｂ",
+    "red canyon 2",
+    "white land 2",
+    "mute city 3",
+    "rainbow road",
+    "devil's forest 3",
+    "space plant",
+    "sand ocean 2",
+    "port town 2",
+    "big hand",
+    "default",
+    "default",
+    "default",
+    "default",
+    "default",
+    "default",
+    "x",
+    "",
+    "silence 3",
+    "sand ocean 3",
+    "devil's forest 4",
+    "port town 3",
+    "devil's forest 5",
+    "big blue 3",
+    "mute city 4",
+    "space plant 2",
+    "port town 4",
+    "fire field 2",
+    "white land 3",
+    "big foot",
+};
+
+const char* gMachineNames[] = { "blue falcon",   "golden fox",       "wild goose",    "fire stingray",  "white cat",
+                                "red gazelle",   "great star",       "iron tiger",    "deep claw",      "twin noritta",
+                                "super piranha", "mighty hurricane", "little wyvern", "space angler",   "green panther",
+                                "black bull",    "wild boar",        "astro robin",   "king meteor",    "queen meteor",
+                                "wonder wasp",   "hyper speeder",    "death anchor",  "crazy bear",     "night thunder",
+                                "big fang",      "mighty typhoon",   "mad wolf",      "sonic phantom",  "hell hawk",
+                                "super falcon",  "golden fox",       "wild goose",    "super stingray", "super cat",
+                                "red gazelle" };
+
+// clang-format off
+s32 D_8076CDE4[] = {
+    255, 0, 0,
+    0, 255, 0,
+    255, 255, 100,
+    255, 0, 0,
+};
+// clang-format on
+
+Gfx* func_80709C90(Gfx* gfx, s32 left, s32 top, s32 right, s32 bottom, s32 red, s32 green, s32 blue, s32 alpha) {
+
+    red &= 0xFF;
+    green &= 0xFF;
+    blue &= 0xFF;
+    alpha &= 0xFF;
+    if ((left >= SCREEN_WIDTH) || (top >= SCREEN_HEIGHT)) {
+        return gfx;
+    }
+
+    if (left < 0) {
+        left = 0;
+    }
+    if (top < 0) {
+        top = 0;
+    }
+    if ((right < 0) || (bottom < 0)) {
+        return gfx;
+    }
+
+    if (right > SCREEN_WIDTH) {
+        right = SCREEN_WIDTH;
+    }
+    if (bottom > SCREEN_HEIGHT) {
+        bottom = SCREEN_HEIGHT;
+    }
+
+    gSPDisplayList(gfx++, D_3000088);
+    gDPSetCombineMode(gfx++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
+    gDPSetPrimColor(gfx++, 0, 0, red, green, blue, alpha);
+    gDPFillRectangle(gfx++, left, top, right, bottom);
+    gDPPipeSync(gfx++);
+    return gfx;
+}
+
+void func_80709DEC(u16* arg0, s32 arg1) {
+    u32 i;
+    u32 colorBlend;
+    u32 red, green, blue, alpha;
+
+    for (i = 0; i < (arg1 / 2); i++, arg0++) {
+        red = ((*arg0 & 0xF800) >> 11) * 77;
+        green = ((*arg0 & 0x7C0) >> 6) * 150;
+        blue = ((*arg0 & 0x3E) >> 1) * 29;
+        alpha = *arg0 & 0x1;
+
+        colorBlend = (red + green + blue) >> 8;
+
+        *arg0 = (colorBlend << 1) + (colorBlend << 6) + (colorBlend << 11) + alpha;
+    }
+}
+
+void func_8070A078(u16* arg0, size_t size, s32 arg2, s32 arg3, s32 arg4) {
+    u32 i;
+    u32 colorBlend;
+    u32 red, green, blue, alpha;
+
+    for (i = 0; i < (size / sizeof(u16)); i++, arg0++) {
+        red = ((*arg0 & 0xF800) >> 11) * 77;
+        green = ((*arg0 & 0x7C0) >> 6) * 150;
+        blue = ((*arg0 & 0x3E) >> 1) * 29;
+        alpha = *arg0 & 0x1;
+
+        colorBlend = (red + green + blue) >> 8;
+
+        *arg0 = (((arg2 * colorBlend) >> 8) << 11) + (((arg3 * colorBlend) >> 8) << 6) +
+                (((arg4 * colorBlend) >> 8) << 1) + alpha;
+    }
+}
+
+Gfx* func_8070A3D8(Gfx* gfx) {
+    gSPDisplayList(gfx++, D_30001A8);
+    return gfx;
+}
+
+extern s16 D_8076C7A4;
+extern FrameBuffer* gFrameBuffers[];
+extern s32 D_8079A35C;
+extern s32 D_8079A364;
+
+Gfx* func_8070A3F4(Gfx* gfx) {
+
+    gDPPipeSync(gfx++);
+
+    if (D_8076C7A4 == 2) {
+        gDPSetColorImage(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH,
+                         OS_PHYSICAL_TO_K0(gFrameBuffers[D_8079A35C]));
+    } else {
+        gDPSetColorImage(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_16b, SCREEN_WIDTH,
+                         OS_PHYSICAL_TO_K0(gFrameBuffers[D_8079A364]));
+    }
+    return gfx;
+}
+
+#define PACK_5551(r, g, b, a) (((((r) << 11) | ((g) << 6)) | ((b) << 1)) | (a))
+
+Gfx* func_8070A498(Gfx* gfx, u16 red, u16 green, u16 blue) {
+
+    if ((red < 0) || (red > 255) || (green < 0) || (green > 255) || (blue < 0) || (blue > 255)) {
+        return gfx;
+    }
+
+    red >>= 3;
+    green >>= 3;
+    blue >>= 3;
+    gDPPipeSync(gfx++);
+    gDPSetCycleType(gfx++, G_CYC_FILL);
+    gDPSetFillColor(gfx++, PACK_5551(red, green, blue, 1) << 16 | PACK_5551(red, green, blue, 1));
+    gDPFillRectangle(gfx++, 12, 8, 307, 231);
+    return gfx;
+}
+
+Gfx* func_8070A594(Gfx* gfx, u16 red, u16 green, u16 blue, s32 left, s32 top, s32 right, s32 bottom) {
+
+    if ((red < 0) || (red > 255) || (green < 0) || (green > 255) || (blue < 0) || (blue > 255)) {
+        return gfx;
+    }
+
+    red >>= 3;
+    green >>= 3;
+    blue >>= 3;
+    gDPPipeSync(gfx++);
+    gDPSetCycleType(gfx++, G_CYC_FILL);
+    gDPSetFillColor(gfx++, PACK_5551(red, green, blue, 1) << 16 | PACK_5551(red, green, blue, 1));
+    gDPFillRectangle(gfx++, left, top, right, bottom);
+    return gfx;
+}
+
+extern Gfx D_8076CAF8[];
+
+// New Gfx in N64DD
+Gfx* func_8070A6C0(Gfx* gfx) {
+    gSPDisplayList(gfx++, D_8076CAF8);
+    return gfx;
+}
+
+Gfx* func_8070A6DC(Gfx* gfx, s32 left, s32 top, s32 right, s32 bottom, s32 red, s32 green, s32 blue, s32 alpha) {
+    gDPPipeSync(gfx++);
+    gDPSetPrimColor(gfx++, 0, 0, red, green, blue, alpha);
+    gSPDisplayList(gfx++, D_3000000);
+    gDPFillRectangle(gfx++, left, top, right, bottom);
+
+    return gfx;
+}
+
+Gfx* func_8070A790(Gfx* gfx, s32 left, s32 top, s32 right, s32 bottom, s32 red, s32 green, s32 blue, s32 alpha) {
+    gDPPipeSync(gfx++);
+    gDPSetPrimColor(gfx++, 0, 0, red, green, blue, alpha);
+    gSPDisplayList(gfx++, D_3000028);
+    gDPFillRectangle(gfx++, left, top, right, bottom);
+
+    return gfx;
+}
+
+extern u32 gGameFrameCount;
+
+Gfx* func_8070A844(Gfx* gfx, s32 left, s32 top, s32 right, s32 bottom) {
+    gSPDisplayList(gfx++, D_3000270);
+    gSPTextureRectangle(gfx++, (left + 1) << 2, (top + 1) << 2, (right - 1) << 2, (bottom - 1) << 2, G_TX_RENDERTILE, 0,
+                        (gGameFrameCount % 32) << 5, 1 << 10, 1 << 10);
+
+    return gfx;
+}
+
+Gfx* func_8070A8F8(Gfx* gfx, s32 left, s32 top, s32 right, s32 bottom) {
+    gDPPipeSync(gfx++);
+    gDPSetRenderMode(gfx++,
+                     IM_RD | CVG_DST_FULL | ZMODE_OPA | CVG_X_ALPHA | FORCE_BL |
+                         GBL_c1(G_BL_CLR_MEM, G_BL_0, G_BL_CLR_MEM, G_BL_1MA),
+                     IM_RD | CVG_DST_FULL | ZMODE_OPA | CVG_X_ALPHA | FORCE_BL |
+                         GBL_c2(G_BL_CLR_MEM, G_BL_0, G_BL_CLR_MEM, G_BL_1MA));
+    gDPSetCombineMode(gfx++, G_CC_SHADE, G_CC_SHADE);
+    gDPSetCycleType(gfx++, G_CYC_1CYCLE);
+    gDPFillRectangle(gfx++, left, top, right, bottom);
+
+    return gfx;
+}
+
+Gfx* func_8070A99C(Gfx* gfx, TexturePtr texture, s32 left, s32 top, s32 width, u32 height, s32 format, s32 size,
+                   s32 arg8, s32 arg9, s32 argA, s32 argB) {
+    s32 i;
+    s32 numBlocks;
+    s32 blockHeight;
+    s32 blockWidth = width;
+    s32 pad[1];
+    s32 sp48;
+    s32 var;
+    s32 var_t0;
+    s32 spE4;
+    s32 spE0;
+    s32 var_a0;
+    s32 dsdx;
+    s32 dtdy;
+    s32 spCC;
+    s32 spC8;
+    s32 spC4;
+    s32 spC0;
+    s32 sTemp = 1;
+
+    if (blockWidth & 3) {
+        return gfx;
+    }
+
+    switch (size) {
+        case G_IM_SIZ_4b:
+            var_t0 = G_IM_SIZ_4b_LOAD_BLOCK;
+            spC8 = G_IM_SIZ_4b_INCR;
+            spC4 = G_IM_SIZ_4b_SHIFT;
+            spC0 = G_IM_SIZ_4b_BYTES;
+            var_a0 = 0x1000;
+            break;
+        case G_IM_SIZ_8b:
+            var_t0 = G_IM_SIZ_8b_LOAD_BLOCK;
+            spCC = G_IM_SIZ_8b_LINE_BYTES;
+            spC8 = G_IM_SIZ_8b_INCR;
+            spC4 = G_IM_SIZ_8b_SHIFT;
+            spC0 = G_IM_SIZ_8b_BYTES;
+            var_a0 = 0x800;
+            break;
+        case G_IM_SIZ_16b:
+            var_t0 = G_IM_SIZ_16b_LOAD_BLOCK;
+            spCC = G_IM_SIZ_16b_LINE_BYTES;
+            spC8 = G_IM_SIZ_16b_INCR;
+            spC4 = G_IM_SIZ_16b_SHIFT;
+            spC0 = G_IM_SIZ_16b_BYTES;
+            var_a0 = 0x400;
+            break;
+        case G_IM_SIZ_32b:
+            var_t0 = G_IM_SIZ_32b_LOAD_BLOCK;
+            spCC = G_IM_SIZ_32b_LINE_BYTES;
+            spC8 = G_IM_SIZ_32b_INCR;
+            spC4 = G_IM_SIZ_32b_SHIFT;
+            spC0 = G_IM_SIZ_32b_BYTES;
+            var_a0 = 0x200;
+            break;
+        default:
+            return gfx;
+    }
+
+    blockHeight = var_a0 / blockWidth;
+    while (height < blockHeight / 2) {
+        blockHeight /= 2;
+    }
+
+    if ((blockHeight % 4) && (size == G_IM_SIZ_4b)) {
+        blockHeight /= 4;
+        blockHeight *= 4;
+    }
+    numBlocks = height / blockHeight;
+
+    if (argA != 0) {
+        dsdx = -0x400;
+        spE0 = (blockWidth - sTemp) << 5;
+    } else {
+        dsdx = 0x400;
+        spE0 = 0;
+    }
+
+    switch (arg8) {
+        case 1:
+            gSPDisplayList(gfx++, D_3000088);
+            break;
+        case 2:
+            gSPDisplayList(gfx++, D_3000100);
+            break;
+        case 3:
+            gSPDisplayList(gfx++, D_3000138);
+            break;
+        case 0:
+        default:
+            gSPDisplayList(gfx++, D_3000050);
+            break;
+    }
+
+    if (arg9 == 0) {
+        gDPSetTextureImage(gfx++, format, var_t0, blockWidth, texture);
+
+        gDPSetTile(gfx++, format, var_t0, 0, 0, G_TX_LOADTILE, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
+                   G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
+
+        if (size == G_IM_SIZ_4b) {
+            gDPSetTile(gfx++, format, size, ((blockWidth >> 1) + 7) >> 3, 0, G_TX_RENDERTILE, 0,
+                       G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                       G_TX_NOLOD);
+        } else {
+            gDPSetTile(gfx++, format, size, ((blockWidth * spCC) + 7) >> 3, 0, G_TX_RENDERTILE, 0,
+                       G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                       G_TX_NOLOD);
+        }
+    } else if (size == G_IM_SIZ_4b) {
+        gDPSetTextureImage(gfx++, format, 1, blockWidth >> 1, texture);
+
+        gDPSetTile(gfx++, format, 1, ((blockWidth >> 1) + 7) >> 3, 0, G_TX_LOADTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
+
+        gDPSetTile(gfx++, format, 0, ((blockWidth * size) + 7) >> 3, 0, G_TX_RENDERTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
+    } else {
+        gDPSetTextureImage(gfx++, format, size, blockWidth, texture);
+
+        gDPSetTile(gfx++, format, size, ((blockWidth * size) + 7) >> 3, 0, G_TX_LOADTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
+
+        gDPSetTile(gfx++, format, size, ((blockWidth * size) + 7) >> 3, 0, G_TX_RENDERTILE, 0,
+                   G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                   G_TX_NOLOD);
+    }
+
+    gDPSetTileSize(gfx++, G_TX_RENDERTILE, 0, 0, (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                   (blockHeight - 1) << G_TEXTURE_IMAGE_FRAC);
+
+    if (argB != 0) {
+        sp48 = height % blockHeight;
+        for (i = 0; i < numBlocks; i++) {
+            gDPLoadSync(gfx++);
+            if (arg9 == 0) {
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, i * blockHeight,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT_4b(blockWidth));
+                } else {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, i * blockHeight,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT(blockWidth, spC0));
+                }
+
+                gSPScisTextureRectangle(gfx++, left << 2,
+                                        (s32) (top + ((numBlocks - i - 1) * blockHeight) + (height % blockHeight)) << 2,
+                                        (left + blockWidth) << 2,
+                                        (s32) (top + ((numBlocks - i) * blockHeight) + (height % blockHeight)) << 2,
+                                        G_TX_RENDERTILE, spE0, (blockHeight - 1) << 5, dsdx, (64 - 1) * (1 << 10));
+            } else {
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (i * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((i + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                } else {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (i * blockHeight) << (G_TEXTURE_IMAGE_FRAC - 1),
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((i + 1) * blockHeight) - 1) << (G_TEXTURE_IMAGE_FRAC - 1));
+                }
+
+                gDPSetTileSize(gfx++, G_TX_RENDERTILE, 0, (i * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                               (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                               (((i + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+
+                //! @bug s and t are swapped around from expected
+                gSPScisTextureRectangle(
+                    gfx++, left << 2, (s32) (top + ((numBlocks - i - 1) * blockHeight) + (height % blockHeight)) << 2,
+                    (left + blockWidth) << 2,
+                    (s32) (top + ((numBlocks - i) * blockHeight) + (height % blockHeight)) << 2, G_TX_RENDERTILE, spE0,
+                    (((i + 1) * blockHeight) - 1) << 5, dsdx, (64 - 1) * (1 << 10));
+            }
+        }
+
+        if (height % blockHeight) {
+            gDPLoadSync(gfx++);
+            if (arg9 == 0) {
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, numBlocks * blockHeight,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT_4b(blockWidth));
+                } else {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, numBlocks * blockHeight,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT(blockWidth, spC0));
+                }
+
+                gSPScisTextureRectangle(gfx++, left << 2, top << 2, (left + blockWidth) << 2,
+                                        (top + (height % blockHeight)) << 2, G_TX_RENDERTILE, spE0,
+                                        ((height % blockHeight) - 1) << 5, dsdx, (64 - 1) * (1 << 10));
+            } else {
+                //! @bug, condition blocks switched around from what size would expect
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (numBlocks * blockHeight) << (G_TEXTURE_IMAGE_FRAC - 1),
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((numBlocks + 1) * blockHeight) - 1) << (G_TEXTURE_IMAGE_FRAC - 1));
+                } else {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (numBlocks * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((numBlocks + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                }
+
+                gDPSetTileSize(gfx++, G_TX_RENDERTILE, 0, (numBlocks * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                               (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                               (((numBlocks + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                gSPScisTextureRectangle(gfx++, left << 2, top << 2, (left + blockWidth) << 2,
+                                        (top + (height % blockHeight)) << 2, G_TX_RENDERTILE, spE0, (height - 1) << 5,
+                                        dsdx, (64 - 1) * (1 << 10));
+            }
+        }
+    } else {
+        for (i = 0; i < numBlocks; i++) {
+            // FAKE?
+            var = i + 1;
+            gDPLoadSync(gfx++);
+            if (arg9 == 0) {
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, i * blockHeight / 4,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT_4b(blockWidth));
+                } else {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, i * blockHeight,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT(blockWidth, spC0));
+                }
+
+                gSPScisTextureRectangle(gfx++, left << 2, (top + (i * blockHeight)) << 2, (left + blockWidth) << 2,
+                                        (top + (var * blockHeight)) << 2, G_TX_RENDERTILE, spE0, 0, dsdx, 1 << 10);
+            } else {
+                //! @bug, condition blocks switched around from what size would expect
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (i * blockHeight) << (G_TEXTURE_IMAGE_FRAC - 1),
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((i + 1) * blockHeight) - 1) << (G_TEXTURE_IMAGE_FRAC - 1));
+                } else {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (i * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((i + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                }
+
+                gDPSetTileSize(gfx++, G_TX_RENDERTILE, 0, (i * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                               (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                               (((i + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                gSPScisTextureRectangle(gfx++, left << 2, (top + (i * blockHeight)) << 2, (left + blockWidth) << 2,
+                                        (top + (var * blockHeight)) << 2, G_TX_RENDERTILE, spE0, (i * blockHeight) << 5,
+                                        dsdx, 1 << 10);
+            }
+        }
+
+        if (height % blockHeight) {
+            gDPLoadSync(gfx++);
+            if (arg9 == 0) {
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, numBlocks * blockHeight / 4,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT_4b(blockWidth));
+                } else {
+                    gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, numBlocks * blockHeight,
+                                 ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT(blockWidth, spC0));
+                }
+
+                gSPScisTextureRectangle(gfx++, left << 2, (s32) (top + ((numBlocks * blockHeight))) << 2,
+                                        (left + blockWidth) << 2,
+                                        (s32) (top + (numBlocks * blockHeight) + (height % blockHeight)) << 2,
+                                        G_TX_RENDERTILE, spE0, 0, dsdx, 1 << 10);
+            } else {
+                //! @bug, condition blocks switched around from what size would expect
+                if (size == G_IM_SIZ_4b) {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (numBlocks * blockHeight) << (G_TEXTURE_IMAGE_FRAC - 1),
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((numBlocks + 1) * blockHeight) - 1) << (G_TEXTURE_IMAGE_FRAC - 1));
+                } else {
+                    gDPLoadTile(gfx++, G_TX_LOADTILE, 0, (numBlocks * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                                (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                                (((numBlocks + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                }
+
+                gDPSetTileSize(gfx++, G_TX_RENDERTILE, 0, (numBlocks * blockHeight) << G_TEXTURE_IMAGE_FRAC,
+                               (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                               (((numBlocks + 1) * blockHeight) - 1) << G_TEXTURE_IMAGE_FRAC);
+                gSPScisTextureRectangle(gfx++, left << 2, (s32) (top + (numBlocks * blockHeight)) << 2,
+                                        (left + blockWidth) << 2,
+                                        (s32) (top + (numBlocks * blockHeight) + (height % blockHeight)) << 2,
+                                        G_TX_RENDERTILE, spE0, (numBlocks * blockHeight) << 5, dsdx, 1 << 10);
+            }
+        }
+    }
+
+    return gfx;
+}
+
+Gfx* func_8070C600(Gfx* gfx, TexturePtr texture, s32 left, s32 top, s32 width, u32 height, f32 arg6, f32 arg7,
+                   s32 format, s32 size, s32 argA, s32 argB, s32 argC) {
+    s32 i;
+    s32 numBlocks;
+    s32 blockHeight;
+    s32 blockWidth = width;
+    s32 pad[5];
+    s32 spE0;
+    s32 var_a0;
+    s32 dsdx;
+    s32 dtdy;
+    s32 var_t0;
+    s32 spCC;
+    s32 spC8;
+    s32 spC4;
+    s32 spC0;
+    f32 temp;
+    s32 sTemp = 1;
+
+    if (blockWidth & 3) {
+        return gfx;
+    }
+    if ((arg6 == 0.0) || (arg7 == 0.0)) {
+        return gfx;
+    }
+
+    switch (size) {
+        case G_IM_SIZ_4b:
+            var_t0 = G_IM_SIZ_4b_LOAD_BLOCK;
+            spC8 = G_IM_SIZ_4b_INCR;
+            spC4 = G_IM_SIZ_4b_SHIFT;
+            spC0 = G_IM_SIZ_4b_BYTES;
+            var_a0 = 0x1000;
+            break;
+        case G_IM_SIZ_8b:
+            var_t0 = G_IM_SIZ_8b_LOAD_BLOCK;
+            spCC = G_IM_SIZ_8b_LINE_BYTES;
+            spC8 = G_IM_SIZ_8b_INCR;
+            spC4 = G_IM_SIZ_8b_SHIFT;
+            spC0 = G_IM_SIZ_8b_BYTES;
+            var_a0 = 0x800;
+            break;
+        case G_IM_SIZ_16b:
+            var_t0 = G_IM_SIZ_16b_LOAD_BLOCK;
+            spCC = G_IM_SIZ_16b_LINE_BYTES;
+            spC8 = G_IM_SIZ_16b_INCR;
+            spC4 = G_IM_SIZ_16b_SHIFT;
+            spC0 = G_IM_SIZ_16b_BYTES;
+            var_a0 = 0x400;
+            break;
+        case G_IM_SIZ_32b:
+            var_t0 = G_IM_SIZ_32b_LOAD_BLOCK;
+            spCC = G_IM_SIZ_32b_LINE_BYTES;
+            spC8 = G_IM_SIZ_32b_INCR;
+            spC4 = G_IM_SIZ_32b_SHIFT;
+            spC0 = G_IM_SIZ_32b_BYTES;
+            var_a0 = 0x200;
+            break;
+        default:
+            return gfx;
+    }
+
+    if (argB == 0) {
+        blockHeight = var_a0 / blockWidth;
+        while (height < blockHeight / 2) {
+            blockHeight /= 2;
+        }
+    } else {
+        blockHeight = 1;
+    }
+
+    numBlocks = height / blockHeight;
+
+    if (argC != 0) {
+        dsdx = -0x400;
+        dtdy = 0x400;
+        spE0 = (blockWidth - sTemp) << 5;
+    } else {
+        dsdx = 0x400;
+        dtdy = 0x400;
+        spE0 = 0;
+    }
+
+    switch (argA) {
+        case 1:
+            gSPDisplayList(gfx++, D_3000088);
+            break;
+        case 2:
+            gSPDisplayList(gfx++, D_3000100);
+            break;
+        case 3:
+            gSPDisplayList(gfx++, D_3000138);
+            break;
+        case 0:
+        default:
+            gSPDisplayList(gfx++, D_3000050);
+            break;
+    }
+
+    dsdx /= arg6;
+    dtdy /= arg7;
+
+    gDPSetTextureImage(gfx++, format, var_t0, blockWidth, texture);
+
+    gDPSetTile(gfx++, format, var_t0, 0, 0, G_TX_LOADTILE, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD,
+               G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
+
+    if (size == G_IM_SIZ_4b) {
+        gDPSetTile(gfx++, format, size, ((blockWidth >> 1) + 7) >> 3, 0, G_TX_RENDERTILE, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                   G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD);
+    } else {
+        gDPSetTile(gfx++, format, size, ((blockWidth * spCC) + 7) >> 3, 0, G_TX_RENDERTILE, 0,
+                   G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                   G_TX_NOLOD);
+    }
+
+    gDPSetTileSize(gfx++, G_TX_RENDERTILE, 0, 0, (blockWidth - 1) << G_TEXTURE_IMAGE_FRAC,
+                   (blockHeight - 1) << G_TEXTURE_IMAGE_FRAC);
+
+    temp = blockHeight * arg7;
+
+    for (i = 0; i < numBlocks; i++) {
+        gDPLoadSync(gfx++);
+        if (size == G_IM_SIZ_4b) {
+            gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, i * blockHeight, ((blockWidth * blockHeight + spC8) >> spC4) - 1,
+                         CALC_DXT_4b(blockWidth));
+        } else {
+            gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, i * blockHeight, ((blockWidth * blockHeight + spC8) >> spC4) - 1,
+                         CALC_DXT(blockWidth, spC0));
+        }
+
+        gSPScisTextureRectangle(
+            gfx++, left << 2, (top + (s32) (i * temp)) << 2, (left + (s32) (blockWidth * arg6)) << 2,
+            (top + (s32) ((i + 1) * (blockHeight * arg7))) << 2, G_TX_RENDERTILE, spE0, 0, dsdx, dtdy);
+    }
+
+    if (height % blockHeight) {
+        gDPLoadSync(gfx++);
+        if (size == G_IM_SIZ_4b) {
+            gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, numBlocks * blockHeight,
+                         ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT_4b(blockWidth));
+        } else {
+            gDPLoadBlock(gfx++, G_TX_LOADTILE, 0, numBlocks * blockHeight,
+                         ((blockWidth * blockHeight + spC8) >> spC4) - 1, CALC_DXT(blockWidth, spC0));
+        }
+
+        gSPScisTextureRectangle(gfx++, left << 2, (top + (s32) (numBlocks * temp)) << 2,
+                                (left + (s32) (blockWidth * arg6)) << 2, (top + (s32) (height * arg7)) << 2,
+                                G_TX_RENDERTILE, spE0, 0, dsdx, dtdy);
+    }
+
+    return gfx;
+}
+
+extern u8 gEditCupTrackNames[][9];
+
+void func_8070D220(void) {
+    s32 i;
+
+    for (i = 24; i < 30; i++) {
+        if (gEditCupTrackNames[i - 24][0] == '\0') {
+            gTrackNames[i] = sTrackNames[i];
+        } else {
+            gTrackNames[i] = gEditCupTrackNames[i - 24];
+        }
+    }
+}
+
+void func_8070D358(void) {
+    s32 i;
+
+    for (i = 0; i < 24; i++) {
+        gTrackNames[i] = sTrackNames[i];
+    }
+
+    func_8070D220();
+
+    for (i = 30; i < 42; i++) {
+        gTrackNames[i] = sTrackNames[i + 2];
+    }
+
+    for (i = 42; i < 48; i++) {
+        gTrackNames[i] = sTrackNames[31];
+    }
+
+    for (i = 48; i < 54; i++) {
+        gTrackNames[i] = sTrackNames[30];
+    }
+
+    gTrackNames[54] = sTrackNames[31];
+}
+
+void Controller_SetGlobalInputs(Controller* controller) {
+    gInputButtonPressed = controller->buttonPressed | STICK_TO_BUTTON(controller->stickPressed);
+    if (controller->unk_82 != 0) {
+        gStickPressed = controller->buttonCurrent | STICK_TO_BUTTON(controller->stickCurrent);
+    } else {
+        gStickPressed = 0;
+    }
+    gInputPressed = gInputButtonPressed | gStickPressed;
+}
+
+extern u32 gGameFrameCount;
+
+Gfx* func_8070D4A8(Gfx* gfx, s32 arg1) {
+    s32 temp_a3;
+    s32 temp_a2;
+    s32 red;
+    s32 green;
+    s32 blue;
+    s32 temp_hi;
+    s32* temp_a0;
+
+    temp_hi = ((gGameFrameCount % 300) * 8) % 300;
+    temp_a2 = temp_hi % 100;
+    temp_a3 = 100 - temp_a2;
+    temp_a0 = &D_8076CDE4[((temp_hi / 100) % 3) * 3];
+
+    switch (arg1) {
+        case 0:
+            red = ((temp_a0[0] * temp_a3) + (temp_a0[3] * temp_a2)) / 100;
+            green = ((temp_a0[1] * temp_a3) + (temp_a0[4] * temp_a2)) / 100;
+            blue = ((temp_a0[2] * temp_a3) + (temp_a0[5] * temp_a2)) / 100;
+            break;
+        case 1:
+        default:
+            red = ((temp_a0[0] * temp_a2) + (temp_a0[3] * temp_a3)) / 100;
+            green = ((temp_a0[1] * temp_a2) + (temp_a0[4] * temp_a3)) / 100;
+            blue = ((temp_a0[2] * temp_a2) + (temp_a0[5] * temp_a3)) / 100;
+            break;
+    }
+
+    gDPSetPrimColor(gfx++, 0, 0, red, green, blue, 255);
+    return gfx;
+}
+
+void func_8070D858(void) {
+    s32 i;
+
+    for (i = 0; i < 4; i++) {
+        gCupNumDifficultiesCleared[i] = 0;
+    }
+}
+
+extern s32 gCupType;
+extern s32 gDifficulty;
+extern s16 D_8079FC7C;
+
+void func_8070D870(void) {
+    s32 i;
+    bool var_v1;
+    bool var_a1;
+    s32 var_a0;
+    s32 cupType;
+
+    switch (gCupType) {
+        case EDIT_CUP:
+            return;
+        case CUP_6:
+        case CUP_7:
+            var_a1 = true;
+            break;
+        default:
+            var_a1 = false;
+            break;
+    }
+
+    var_v1 = false;
+    if (var_a1) {
+        for (i = 0; i < 2; i++) {
+            if (D_8079FB28[i] < 3) {
+                var_v1 = true;
+                break;
+            }
+        }
+    } else {
+        for (i = 0; i < 4; i++) {
+            if (gCupNumDifficultiesCleared[i] < 3) {
+                var_v1 = true;
+                break;
+            }
+        }
+    }
+    cupType = gCupType;
+    var_a0 = gDifficulty + 1;
+    if (var_a0 > MASTER + 1) {
+        var_a0 = MASTER + 1;
+    }
+    if (var_a1) {
+        if (D_8079FB28[cupType - CUP_6] < var_a0) {
+            D_8079FB28[cupType - CUP_6] = var_a0;
+        }
+        if (var_v1) {
+            for (i = 0; i < 2; i++) {
+                if (D_8079FB28[i] < 3) {
+                    var_v1 = false;
+                }
+            }
+
+            if (var_v1) {
+                D_8079FC7C = 1;
+            }
+        }
+    } else {
+        if (gCupNumDifficultiesCleared[cupType] < var_a0) {
+            gCupNumDifficultiesCleared[cupType] = var_a0;
+        }
+        if (var_v1) {
+            for (i = 0; i < 4; i++) {
+                if (gCupNumDifficultiesCleared[i] < 3) {
+                    var_v1 = false;
+                }
+            }
+
+            if (var_v1) {
+                D_8079FC7C = 1;
+            }
+        }
+        Save_SaveSettingsProfiles();
+    }
+}
+
+s32 func_8070DA54(void) {
+    s32 sum = 0;
+    s32 i;
+
+    for (i = 0; i < 4; i++) {
+        sum += gCupNumDifficultiesCleared[i];
+    }
+    return sum;
+}
+
+void func_8070DA84(void) {
+    func_807423F4(0);
+}
+
+void func_8070DAA4(s32 arg0) {
+
+    if (arg0 == 0x1D) {
+        arg0 = 0x11;
+    }
+    func_80741A0C(arg0);
+}
+
+void func_8070DAD4(s32 arg0) {
+    func_80741CB4(arg0);
+    D_8076CCA0 = true;
+}
+
+void func_8070DAFC(void) {
+    func_80741BCC();
+    if (D_8076CCA0) {
+        func_80741DD4();
+    } else {
+        func_80741B84();
+    }
+    D_8076CCA0 = false;
+}
+
+void func_8070DB48(void) {
+    func_80741BCC();
+    if (D_8076CCA0) {
+        func_80741E64();
+    } else {
+        func_80741B84();
+    }
+    D_8076CCA0 = false;
+}
+
+void func_8070DB94(void) {
+    func_80742004();
+    if (D_8076CCA0) {
+        func_80741DD4();
+    } else {
+        func_80741B84();
+    }
+    D_8076CCA0 = false;
+}
+
+const s8 kMachineSelectCharacterList[] = { CAPTAIN_FALCON,
+                                           DR_STEWART,
+                                           PICO,
+                                           SAMURAI_GOROH,
+                                           JODY_SUMMER,
+                                           MIGHTY_GAZELLE,
+                                           BABA,
+                                           OCTOMAN,
+                                           DR_CLASH,
+                                           MR_EAD,
+                                           BIO_REX,
+                                           BILLY,
+                                           SILVER_NEELSEN,
+                                           GOMAR_AND_SHIOH,
+                                           JOHN_TANAKA,
+                                           MRS_ARROW,
+                                           BLOOD_FALCON,
+                                           JACK_LEVIN,
+                                           JAMES_MCCLOUD,
+                                           ZODA,
+                                           MICHAEL_CHAIN,
+                                           SUPER_ARROW,
+                                           KATE_ALEN,
+                                           ROGER_BUSTER,
+                                           LEON,
+                                           DRAQ,
+                                           BEASTMAN,
+                                           ANTONIO_GUSTER,
+                                           BLACK_SHADOW,
+                                           THE_SKULL,
+                                           30 };
+
+s32 func_8070DBE0(s32 i) {
+    return kMachineSelectCharacterList[i];
+}
+
+s32 func_8070DBF0(s32 character) {
+    s32 i;
+
+    for (i = 0; i < 30; i++) {
+        if (character == kMachineSelectCharacterList[i]) {
+            return i;
+        }
+    }
+
+    return 0;
+}
+
+void func_8070DC94(void) {
+    GhostInfo sp40;
+    s32 pad;
+    bool sp38;
+    s32 i;
+
+    sp38 = false;
+
+    for (i = 0; i < 24; i++) {
+        if (Save_LoadStaffGhostRecord(&sp40, i) != 0) {
+            sp38 = true;
+            break;
+        } else {
+            if (gCourseInfos[i].timeRecord[0] >= sp40.raceTime) {
+                sp38 = true;
+                break;
+            }
+        }
+    }
+    if (!sp38 || (gUnlockableLevel >= 3)) {
+        D_8076CC94 = 2;
+    } else if (gUnlockableLevel >= 2) {
+        D_8076CC94 = 1;
+    } else {
+        D_8076CC94 = 0;
+    }
+}
+
+void func_8070DD88(void) {
+    bool var_a0;
+    s32 i;
+
+    if (func_8070DA54() >= 16) {
+        gUnlockableLevel = 3;
+    } else {
+        var_a0 = false;
+        for (i = JACK_CUP; i <= JOKER_CUP; i++) {
+            if (gCupNumDifficultiesCleared[i] < 3) {
+                var_a0 = true;
+                break;
+            }
+        }
+
+        if (!var_a0) {
+            gUnlockableLevel = 2;
+        } else {
+            var_a0 = false;
+            for (i = JACK_CUP; i <= KING_CUP; i++) {
+                if (gCupNumDifficultiesCleared[i] < 2) {
+                    var_a0 = true;
+                    break;
+                }
+            }
+
+            if (!var_a0) {
+                gUnlockableLevel = 1;
+            } else {
+                gUnlockableLevel = 0;
+            }
+        }
+    }
+    func_8070DC94();
+}
+
+extern s16 D_807A15F0[];
+extern s16 D_807A15F8[];
+
+void func_8070DE6C(void) {
+    s32 i;
+    s32 j;
+
+    for (i = 3; i >= 0; i--) {
+        D_807A15F0[i] = i;
+        D_807A15F8[i] = 0;
+    }
+
+    for (i = 0; i < 8; i++) {
+        gModeSubOption[i] = 0;
+    }
+
+    D_8076CC88 = 0;
+    D_8076CC8C = 0;
+    gCurrentGhostType = GHOST_PLAYER;
+}

--- a/src/1B6E0.c
+++ b/src/1B6E0.c
@@ -1,0 +1,190 @@
+#include "global.h"
+#include "fzx_assets.h"
+
+Gfx* func_8070DEE0(Gfx* gfx, TexturePtr texture, TexturePtr tlutTexture, s32 format, s32 unkTmemFlag, s32 left, s32 top,
+                   s32 width, s32 height, u16 unkDrawFlag) {
+    bool usedPrimitives;
+    u8* texPtr;
+    s32 numBlocks;
+    s32 blockHeight;
+    s32 pixelSize;
+    s32 tmem;
+    s32 row;
+    s32 remainingHeight;
+    s32 blockWidth = width;
+
+    tmem = 0x1000;
+    if (unkTmemFlag == 1) {
+        tmem = 0x800;
+        pixelSize = 1;
+    } else {
+        //! @bug pixelSize uninitialised
+    }
+    blockHeight = (s32) (tmem / pixelSize) / blockWidth;
+    if (unkDrawFlag & 4) {
+        blockHeight = 2;
+    }
+    numBlocks = height / blockHeight;
+
+    usedPrimitives = false;
+    if (unkDrawFlag & 1) {
+        gSPDisplayList(gfx++, D_8014940);
+        usedPrimitives = true;
+        gDPSetTextureLUT(gfx++, G_TT_RGBA16);
+    }
+    if (unkDrawFlag & 2) {
+        if (!usedPrimitives) {
+            gDPPipeSync(gfx++);
+            usedPrimitives = true;
+        }
+        gDPSetCombineMode(gfx++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+    }
+    if (tlutTexture != NULL) {
+        if (!usedPrimitives) {
+            gDPPipeSync(gfx++);
+        }
+
+        gDPLoadTLUT_pal256(gfx++, tlutTexture);
+    }
+
+    for (row = 0, texPtr = texture; row < numBlocks; row++) {
+        gDPPipeSync(gfx++);
+        gDPLoadTextureBlock(gfx++, texPtr, G_IM_FMT_CI, G_IM_SIZ_8b, blockWidth, blockHeight, 0,
+                            G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                            G_TX_NOLOD, G_TX_NOLOD);
+        gSPScisTextureRectangle(gfx++, left << 2, (top + (blockHeight * row)) << 2, (left + blockWidth) << 2,
+                                (top + (blockHeight * (row + 1))) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+
+        texPtr += blockWidth * blockHeight * pixelSize;
+    }
+    remainingHeight = height % blockHeight;
+    if (remainingHeight > 0) {
+        gDPPipeSync(gfx++);
+        gDPLoadTextureBlock(gfx++, texPtr, format, G_IM_SIZ_8b, blockWidth, remainingHeight, 0,
+                            G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK,
+                            G_TX_NOLOD, G_TX_NOLOD);
+        gSPScisTextureRectangle(gfx++, left << 2, (top + (blockHeight * row)) << 2, (left + blockWidth) << 2,
+                                ((top + (blockHeight * row) + (remainingHeight))) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10,
+                                1 << 10);
+    }
+    return gfx;
+}
+
+void func_8070E79C(u16* arg0, s32 arg1) {
+    s32 i;
+    u32 colorBlend;
+    u32 red, green, blue, alpha;
+
+    for (i = 0; i < (arg1 / 2); i++, arg0++) {
+        red = ((*arg0 & 0xF800) >> 11) * 77;
+        green = ((*arg0 & 0x7C0) >> 6) * 150;
+        blue = ((*arg0 & 0x3E) >> 1) * 29;
+        alpha = *arg0 & 0x1;
+
+        colorBlend = (0x1F00 - red - green - blue) >> 8;
+
+        *arg0 = (colorBlend << 1) + (colorBlend << 6) + (colorBlend << 11) + alpha;
+    }
+}
+
+void func_8070EA38(u16* arg0, s32 arg1, s32 arg2) {
+    s32 i;
+    u16 var_v0;
+    u16 temp_a0;
+    u16 temp_a2;
+    u16 temp_t0;
+    u32 red, green, blue;
+
+    var_v0 = GPACK_RGBA5551(0, 0, 0, 1);
+    for (i = 0; i < arg1; i++, arg0++) {
+        temp_a0 = *arg0;
+        temp_a2 = *(arg0 + 1);
+        temp_t0 = *(arg0 + arg2);
+
+        red = (((var_v0 & 0xF800) >> 11)) + (((temp_a0 & 0xF800) >> 11)) + (((temp_a2 & 0xF800) >> 11)) +
+              (((temp_t0 & 0xF800) >> 11));
+        green = (((var_v0 & 0x7C0) >> 6)) + (((temp_a0 & 0x7C0) >> 6)) + (((temp_a2 & 0x7C0) >> 6)) +
+                (((temp_t0 & 0x7C0) >> 6));
+        blue = (((var_v0 & 0x3E) >> 1)) + (((temp_a0 & 0x3E) >> 1)) + (((temp_a2 & 0x3E) >> 1)) +
+               (((temp_t0 & 0x3E) >> 1));
+
+        // clang-format off
+        red /= 4; green /= 4; blue /= 4;
+        // clang-format on
+
+        var_v0 = temp_a0;
+
+        *arg0 = (red << 11) | (green << 6) | (blue << 1) | 1;
+    }
+}
+
+s32 func_8070EB3C(u16* arg0, s32 arg1, u16 arg2) {
+    s32 i;
+    s32 index;
+
+    if (arg1 == 0) {
+        return -1;
+    }
+    index = -1;
+
+    for (i = 0; i < arg1; i++, arg0++) {
+        if (*arg0 == arg2) {
+            index = i;
+            break;
+        }
+    }
+
+    return index;
+}
+
+s32 func_8070EB90(u16* arg0, u16* arg1, s32 arg2) {
+    s32 i;
+    s32 temp_v0;
+    u8* var_s0 = (u8*) arg0;
+    s32 var_s2 = 0;
+    u16* var_s3 = arg1;
+
+    for (i = 0; i < arg2; i++, arg0++) {
+        temp_v0 = func_8070EB3C(arg1, var_s2, *arg0);
+        if (temp_v0 == -1) {
+            if (var_s2 >= 0x100) {
+                return -1;
+            }
+            *var_s0 = var_s2;
+            *var_s3 = *arg0;
+            var_s0++;
+            var_s3++;
+            var_s2++;
+        } else {
+            *var_s0 = temp_v0;
+            var_s0++;
+        }
+    }
+
+    return var_s2;
+}
+
+extern u32 gGameFrameCount;
+
+Gfx* func_8070EC64(Gfx* gfx, s32 arg1, s32 arg2, s32 arg3) {
+    u32 red;
+    u32 green;
+    u32 blue;
+    s32 temp_v0 = gGameFrameCount & 0x10;
+    s32 temp_t0 = gGameFrameCount & 0xF;
+    f32 temp_fv0 = temp_t0 / 15.0f;
+
+    if (!temp_v0) {
+        red = (arg1 - 255) * temp_fv0 + 255.0f;
+        green = (arg2 - 255) * temp_fv0 + 255.0f;
+        blue = (arg3 - 255) * temp_fv0 + 255.0f;
+    } else {
+        red = arg1 + (255 - arg1) * temp_fv0;
+        green = arg2 + (255 - arg2) * temp_fv0;
+        blue = arg3 + (255 - arg3) * temp_fv0;
+    }
+
+    gDPSetPrimColor(gfx++, 0, 0, red, green, blue, 255);
+
+    return gfx;
+}

--- a/src/1C8B0.c
+++ b/src/1C8B0.c
@@ -1,7 +1,83 @@
-#include "common.h"
+#include "global.h"
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1C8B0/func_8070F0B0.s")
+bool D_8076CE20 = false;
+s32 gSkyboxType;
+s32 gVenueType;
+RaceStats gCupRaceStats[1][6];
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1C8B0/func_8070F0D0.s")
+void func_8070F0B0(s32 venue, s32 skybox) {
+    D_8076CE20 = true;
+    gVenueType = venue;
+    gSkyboxType = skybox;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1C8B0/func_8070F0F0.s")
+s8 gRecordNameEntered[4];
+s16 D_8079FC7C;
+
+void func_8070F0D0(void) {
+    s32 i;
+
+    for (i = 0; i < 4; i++) {
+        gRecordNameEntered[i] = 0;
+    }
+
+    D_8079FC7C = 0;
+}
+
+Gfx D_8076CE28[] = {
+    gsSPClipRatio(FRUSTRATIO_2),
+    gsSPMatrix(0x02000000, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    gsDPSetCycleType(G_CYC_FILL),
+    gsDPPipelineMode(G_PM_NPRIMITIVE),
+    gsDPSetRenderMode(G_RM_NOOP, G_RM_NOOP2),
+    gsDPSetCombineMode(G_CC_SHADE, G_CC_SHADE),
+    gsDPSetAlphaCompare(G_AC_NONE),
+    gsDPSetCombineKey(G_CK_NONE),
+    gsDPNoOp(),
+    gsDPSetColorDither(G_CD_MAGICSQ),
+    gsDPSetTextureLOD(G_TL_TILE),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPSetTextureDetail(G_TD_CLAMP),
+    gsDPSetTexturePersp(G_TP_PERSP),
+    gsDPSetTextureFilter(G_TF_BILERP),
+    gsDPSetTextureConvert(G_TC_FILT),
+    gsDPSetDepthImage(0x003DBC00),
+    gsDPSetColorImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, 0x003DBC00),
+    gsDPSetFillColor(0xFFFCFFFC),
+    gsDPSetScissor(G_SC_NON_INTERLACE, 12, 8, 308, 232),
+    gsDPFillRectangle(12, 8, 307, 231),
+    gsDPSetDepthSource(G_ZS_PIXEL),
+    gsDPPipeSync(),
+    gsDPSetCycleType(G_CYC_1CYCLE),
+    gsSPEndDisplayList(),
+};
+
+Gfx D_8076CF10[] = {
+    gsSPClipRatio(FRUSTRATIO_2),
+    gsSPMatrix(0x02000000, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW),
+    gsDPPipeSync(),
+    gsDPSetCycleType(G_CYC_FILL),
+    gsDPPipelineMode(G_PM_NPRIMITIVE),
+    gsDPSetRenderMode(G_RM_NOOP, G_RM_NOOP2),
+    gsDPSetCombineMode(G_CC_SHADE, G_CC_SHADE),
+    gsDPSetAlphaCompare(G_AC_NONE),
+    gsDPSetCombineKey(G_CK_NONE),
+    gsDPNoOp(),
+    gsDPSetColorDither(G_CD_MAGICSQ),
+    gsDPSetTextureLOD(G_TL_TILE),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPSetTextureDetail(G_TD_CLAMP),
+    gsDPSetTexturePersp(G_TP_PERSP),
+    gsDPSetTextureFilter(G_TF_BILERP),
+    gsDPSetTextureConvert(G_TC_FILT),
+    gsDPSetDepthImage(0x003DBC00),
+    gsDPSetColorImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, 0x003DBC00),
+    gsDPSetFillColor(0xFFFCFFFC),
+    gsDPSetScissor(G_SC_NON_INTERLACE, 12, 16, 308, 224),
+    gsDPFillRectangle(12, 16, 307, 223),
+    gsDPSetDepthSource(G_ZS_PIXEL),
+    gsDPPipeSync(),
+    gsDPSetCycleType(G_CYC_1CYCLE),
+    gsSPEndDisplayList(),
+};

--- a/src/1C8F0.c
+++ b/src/1C8F0.c
@@ -1,0 +1,19 @@
+#include "global.h"
+#include "leo/unk_leo.h"
+
+extern LEODiskID D_8076CB50;
+
+#define LEO_DISK_TIME(yearhi, yearlo, month, day, hour, minute, second) \
+    { 0, 0x##yearhi, 0x##yearlo, 0x##month, 0x##day, 0x##hour, 0x##minute, 0x##second }
+
+void func_8070F0F0(void) {
+    // 1999-12-31 23:59:59
+    LEODiskTime diskTime = LEO_DISK_TIME(19, 99, 12, 31, 23, 59, 59);
+
+    func_80762330(&diskTime);
+    func_80760F40("01", "EFZJ");
+    SLMFSCreateManager(LEO_MANAGER_REGION_NONE);
+    func_8070481C();
+    SLLeoReadDiskID(&D_8076CB50);
+    SLLeoModeSelectAsync(0, 0);
+}

--- a/src/1E970.c
+++ b/src/1E970.c
@@ -1,15 +1,230 @@
-#include "common.h"
+#include "global.h"
+#include "fzx_assets.h"
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_80711170.s")
+void func_80711170(unk_800E51B8** arg0) {
+    *arg0 = NULL;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_80711178.s")
+s32 D_807A0870;
+unk_800E51B8 D_807A0878[5];
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_807112A0.s")
+void func_80711178(void) {
+    s32 i;
+    unk_800E51B8* var_v1;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_807113DC.s")
+    D_807A0870 = 0;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_80711414.s")
+    for (i = 0, var_v1 = D_807A0878; i < 5; i++, var_v1++) {
+        var_v1->unk_00 = 0;
+        var_v1->unk_04 = -1;
+        var_v1->unk_06 = var_v1->unk_08 = var_v1->unk_0A = var_v1->unk_0C = var_v1->unk_0E = var_v1->unk_10 =
+            var_v1->unk_12 = 0;
+        var_v1->unk_18 = var_v1->unk_1A = 0;
+    }
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_80711698.s")
+unk_800E51B8* func_807112A0(s16 arg0, s16 arg1, s16 arg2, s16 arg3, s16 arg4, u16 arg5, u16 arg6,
+                            unk_800E51B8_unk_1C_func arg7) {
+    s32 var_v0;
+    s32 i;
+    unk_800E51B8* var_v1;
+    s64 one = 1;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1E970/func_80711AC0.s")
+    for (i = 0, var_v1 = D_807A0878; i < 5; i++, var_v1++) {
+        if (arg0 == var_v1->unk_04) {
+            return NULL;
+        }
+    }
+
+    for (i = 0, var_v1 = D_807A0878; i < 5; i++, var_v1++) {
+        if (var_v1->unk_04 == -1) {
+            break;
+        }
+    }
+
+    if (i == 5) {
+        return NULL;
+    }
+    D_807A0870++;
+    var_v1->unk_00 = one;
+    var_v1->unk_04 = arg0;
+    var_v1->unk_06 = 0;
+    var_v1->unk_08 = arg1 + (arg3 / 2);
+    var_v1->unk_0A = arg2 + ((s32) (arg4 - 2) / 2);
+    var_v1->unk_0C = arg1;
+    var_v1->unk_0E = arg2;
+    var_v1->unk_10 = 0;
+    var_v1->unk_12 = 2;
+    var_v1->unk_14 = arg3;
+    var_v1->unk_16 = arg4;
+    var_v1->unk_18 = GPACK_RGBA5551(0, 0, 0, 1);
+    var_v1->unk_1A = arg6;
+    var_v1->unk_1C = arg5;
+    var_v1->unk_20 = arg7;
+    return var_v1;
+}
+
+void func_807113DC(unk_800E51B8* arg0) {
+    if (arg0 == NULL) {
+        return;
+    }
+    arg0->unk_00 = 4;
+    arg0->unk_06 = 0;
+    arg0->unk_0C = arg0->unk_08;
+    arg0->unk_0E = arg0->unk_0A;
+    arg0->unk_14 = arg0->unk_10;
+    arg0->unk_16 = arg0->unk_12;
+}
+
+void func_80711414(void) {
+    s32 i;
+    unk_800E51B8* var_v1;
+    f32 temp1;
+
+    for (i = 0, var_v1 = D_807A0878; i < 5; i++, var_v1++) {
+        if (var_v1->unk_04 == -1) {
+            continue;
+        }
+
+        switch (var_v1->unk_00) {
+            case 1:
+                var_v1->unk_06++;
+                temp1 = (var_v1->unk_06 / 10.0f);
+
+                var_v1->unk_08 = var_v1->unk_0C + ((s16) ((var_v1->unk_14 / 2.0f) * (1.0f - temp1)));
+                var_v1->unk_10 = var_v1->unk_14 * temp1;
+
+                if (var_v1->unk_06 >= 10) {
+                    var_v1->unk_00 = 2;
+                    var_v1->unk_06 = 0;
+                    var_v1->unk_10 = var_v1->unk_14;
+                    var_v1->unk_08 = var_v1->unk_0C;
+                }
+                break;
+            case 2:
+                var_v1->unk_06++;
+                temp1 = (var_v1->unk_06 / 10.0f);
+
+                var_v1->unk_0A = var_v1->unk_0E + (s16) (((var_v1->unk_16 - 2) / 2.0f) * (1.0f - temp1));
+                var_v1->unk_12 = (s16) ((var_v1->unk_16 - 2) * temp1) + 2;
+
+                if (var_v1->unk_06 >= 10) {
+                    var_v1->unk_00 = 3;
+                    var_v1->unk_06 = 0;
+                    var_v1->unk_12 = var_v1->unk_16;
+                    var_v1->unk_0A = var_v1->unk_0E;
+                }
+                break;
+            case 3:
+                break;
+            case 4:
+                var_v1->unk_06++;
+                temp1 = (var_v1->unk_06 / 10.0f);
+
+                var_v1->unk_0A = var_v1->unk_0E + (s16) (((var_v1->unk_16 - 2) / 2.0f) * temp1);
+                var_v1->unk_12 = (var_v1->unk_16 - 2) * (1.0f - temp1);
+
+                if (var_v1->unk_06 >= 10) {
+                    var_v1->unk_00 = 5;
+                    var_v1->unk_06 = 0;
+                    var_v1->unk_12 = 2;
+                    var_v1->unk_0A = var_v1->unk_0E + ((var_v1->unk_16 - 2) / 2);
+                }
+                break;
+            case 5:
+                var_v1->unk_06++;
+                temp1 = (var_v1->unk_06 / 10.0f);
+
+                var_v1->unk_08 = var_v1->unk_0C + (s16) ((var_v1->unk_14 / 2.0f) * temp1);
+                var_v1->unk_10 = var_v1->unk_14 * (1.0f - temp1);
+
+                if (var_v1->unk_06 >= 11) {
+                    var_v1->unk_00 = 0;
+                    var_v1->unk_04 = -1;
+                    D_807A0870--;
+                }
+                break;
+        }
+    }
+}
+
+Gfx* func_80711698(Gfx* gfx) {
+    s32 i;
+    s32 j;
+    s32 var_s2;
+    unk_800E51B8* var_s0;
+    unk_800E51B8* temp_v0;
+    s16* var_v1;
+    bool var_a0;
+    s16 temp_a2;
+    s16 sp60[5];
+
+    var_s2 = 0;
+    for (i = 0, var_s0 = D_807A0878, var_v1 = sp60; i < 5; i++, var_v1++, var_s0++) {
+        *var_v1 = i;
+        if (var_s0->unk_04 != -1) {
+            var_s2++;
+        }
+    }
+
+    for (i = 0; i < 5; i++) {
+
+        var_s0 = &D_807A0878[sp60[i]];
+        for (j = i + 1; j < 5; j++) {
+            var_a0 = false;
+            temp_v0 = &D_807A0878[sp60[j]];
+
+            if (var_s0->unk_04 == -1) {
+                if (temp_v0->unk_04 != -1) {
+                    var_a0 = true;
+                }
+            } else {
+                if (temp_v0->unk_04 != -1 && temp_v0->unk_1C < var_s0->unk_1C) {
+                    var_a0 = true;
+                }
+            }
+
+            if (var_a0) {
+                temp_a2 = sp60[i];
+                sp60[i] = sp60[j];
+                sp60[j] = temp_a2;
+            }
+        }
+    }
+
+    for (i = 0; i < var_s2; i++, var_s0++) {
+        var_s0 = &D_807A0878[sp60[i]];
+
+        gSPDisplayList(gfx++, D_80149A0);
+        gDPSetFillColor(gfx++, var_s0->unk_1A << 16 | var_s0->unk_1A);
+        gDPFillRectangle(gfx++, var_s0->unk_08, var_s0->unk_0A, ((var_s0->unk_08 + var_s0->unk_10) - 1),
+                         ((var_s0->unk_0A + var_s0->unk_12) - 1));
+
+        gDPPipeSync(gfx++);
+        gDPSetFillColor(gfx++, var_s0->unk_18 << 16 | var_s0->unk_18);
+        gDPFillRectangle(gfx++, var_s0->unk_08 + 1, var_s0->unk_0A + 1, ((var_s0->unk_08 + var_s0->unk_10) - 2),
+                         ((var_s0->unk_0A + var_s0->unk_12) - 2));
+
+        if ((var_s0->unk_20 != NULL) && (var_s0->unk_00 == 3)) {
+            gfx = var_s0->unk_20(gfx, var_s0->unk_08, var_s0->unk_0A);
+        }
+    }
+    return gfx;
+}
+
+bool func_80711AC0(unk_800E51B8* arg0, s32 arg1) {
+    bool ret = false;
+
+    switch (arg1) {
+        case 0:
+            ret = ((arg0 != NULL) && (arg0->unk_00 != 0)) ? true : false;
+            break;
+        case 1:
+            ret = (arg0->unk_00 == 3) ? true : false;
+            break;
+        default:
+            break;
+    }
+
+    return ret;
+}

--- a/src/1F320.c
+++ b/src/1F320.c
@@ -1,265 +1,3025 @@
-#include "common.h"
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711B20.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711B6C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711BF0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711C30.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711CA8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711CE4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711D58.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711DA4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711E28.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711EDC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80711F90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807121D4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712864.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712AA8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712B34.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712BBC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712C44.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712DE0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712E68.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80712FE4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713064.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807130F8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071315C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713204.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807133A0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807134AC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071370C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807138CC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071391C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713AC0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713B00.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713C9C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713D78.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713E38.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713F8C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713FD4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713FDC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713FE4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80713FF4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714000.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071400C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071402C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071403C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714130.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714150.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714178.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807141A0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807141C0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807141E0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714268.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807142F0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071437C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714408.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714538.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714668.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071479C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807148D0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071491C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714968.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807149B8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714A08.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714A54.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714AA0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714AF0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714B40.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714B8C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714BD8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714C28.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714C78.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714D90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714EA8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80714FC4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807150E0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071518C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071523C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807152EC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807153A0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715490.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715580.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715674.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715768.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807157DC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715BE0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715CD8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715E1C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715E60.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715EC0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715F20.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80715F9C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807160A0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807166B8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80716F38.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80717294.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80717354.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807176B4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80717B20.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807181F8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80718530.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80718908.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80718964.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80718AB0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80718AFC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80718F58.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80719140.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_807191B0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80719420.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80719480.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_8071985C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80719868.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/func_80719890.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_807763D0.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776428.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776448.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776640.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_807766A8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776754.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776800.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_807768AC.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_8077699C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776A48.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776A58.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776A60.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776A78.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776A90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776AA8.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776B00.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776B9C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776BF4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776C90.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776C94.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776C9C.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/1F320/D_80776CA8.s")
+#include "global.h"
+#include "fzx_game.h"
+#include "fzx_racer.h"
+#include "fzx_assets.h"
+
+Player gPlayers[4];
+unk_struct_F8 D_807A10A0[4];
+unk_800E5D70 D_807A1480[4];
+unk_struct_20_2 D_807A1510[4];
+s32 D_807A1590;
+s32 D_807A1594;
+s16 D_807A1598;
+s16 D_807A159A;
+UNUSED s16 D_807A159C;
+Vec3f D_807A15A0[4];
+
+const unk_redo_1 D_807763D0 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f },
+};
+
+const unk_redo_2 D_80776448 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+      0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f },
+};
+
+UNUSED const unk_8008112C_arg_1 D_807764F4 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,   0.0f,
+      0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,   1.0f,
+      0.0f, 120.0f, 120.0f, 1.0f, 35.0f, 35.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 300.0f, 0.0f },
+};
+
+const unk_redo_3 D_807765E8 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+};
+
+const unk_redo_2 D_807766A8 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  1.0f,  0.0f, 1.0f,  0.0f,  1.0f, 0.0f,
+      0.0f, 400.0f, 400.0f, 1.0f, 40.0f, 40.0f, 1.0f, 50.0f, 50.0f, 1.0f },
+};
+
+const unk_redo_2 D_80776754 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f,    0.0f,    0.0f, 0.0f,  1.0f,  0.0f, 1.0f,  0.0f,  1.0f, 0.0f,
+      0.0f, 1500.0f, 1500.0f, 1.0f, 35.0f, 35.0f, 1.0f, 50.0f, 50.0f, 1.0f },
+};
+
+const unk_redo_2 D_80776800 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 1.0f, 60.0f, 60.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f,     0.0f,     0.0f, 0.0f,  1.0f,  0.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+      0.0f, 10500.0f, 10500.0f, 1.0f, 20.0f, 20.0f, 1.0f, 0.0f, 0.0f, 1.0f },
+};
+
+const unk_redo_1 D_807768AC = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 4000.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 0.0f, 30.0f, 30.0f, 0.0f, 0.0f,    0.0f, 0.0f, 0.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f },
+};
+
+UNUSED const unk_redo_1 D_80776924 = {
+    { 0.0f, 50.0f, 0.0f,  0.0f,  150.0f, 500.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
+      0.0f, 0.0f,  75.0f, 75.0f, 0.0f,   0.0f,   0.0f, 0.0f, 0.0f, 0.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f },
+};
+
+const unk_redo_2 D_8077699C = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f,  1.0f, 0.0f,  0.0f, 1.0f,
+      0.0f, 1.0f, 75.0f, 75.0f, 1.0f, 0.0f, 77.0f, 0.0f, 77.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f,    0.0f,    0.0f, 0.0f,  1.0f,  0.0f, 1.0f,   0.0f,   1.0f, 0.0f,
+      0.0f, 1000.0f, 1000.0f, 1.0f, 35.0f, 35.0f, 1.0f, 180.0f, 180.0f, 1.0f },
+};
+
+const Vec3f D_80776A48[] = {
+    { 80.0f, 400.0f, 50.0f },
+    { 75.0f, 90.0f, 25.0f },
+    { 75.0f, 120.0f, 35.0f },
+    { 100.0f, 120.0f, 50.0f },
+};
+
+const Vec3f D_80776A78[] = {
+    { 100.0f, 400.0f, 50.0f },
+    { 90.0f, 100.0f, 25.0f },
+    { 100.0f, 120.0f, 35.0f },
+    { 110.0f, 125.0f, 40.0f },
+};
+
+const unk_8008112C_arg_1 D_80776AA8 = {
+    { 0.0f, 0.0f, 0.0f,  0.0f,  0.0f, 400.0f, 0.0f,  1.0f, 0.0f,  0.0f, 1.0f,
+      0.0f, 1.0f, 80.0f, 80.0f, 0.2f, 0.0f,   77.0f, 0.0f, 77.0f, 0.1f, 0.2f },
+    { 0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,   0.0f,
+      0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,   1.0f,
+      0.0f, 400.0f, 400.0f, 0.2f, 50.0f, 50.0f, 0.2f, 0.0f, 0.0f, 1.0f, 0.0f, 300.0f, 0.0f },
+};
+
+const unk_8008112C_arg_1 D_80776B9C = {
+    { 0.0f, 0.0f, 0.0f,   0.0f,   0.0f, 400.0f, 0.0f,   1.0f, 0.0f,   0.0f, 1.0f,
+      0.0f, 1.0f, 100.0f, 100.0f, 0.2f, 0.0f,   -15.0f, 0.0f, -15.0f, 0.1f, 0.2f },
+    { 0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,   0.0f,
+      0.0f, 0.0f,   0.0f,   0.0f, 0.0f,  0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,   1.0f,
+      0.0f, 400.0f, 400.0f, 0.2f, 50.0f, 50.0f, 0.2f, 0.0f, 0.0f, 1.0f, 0.0f, 300.0f, 0.0f },
+};
+
+s32 D_8076D6C0 = -1;
+s32 D_8076D6C4 = 1;
+
+f32 D_8076D6C8[] = {
+    2000.0f,
+    0.0f,
+    25.0f,
+};
+
+f32 D_8076D6D4[] = {
+    4000.0f,
+    -0.9f,
+    50.0f,
+};
+
+f32 D_8076D6E0[] = {
+    -7.0f, 0.0f, 63.0f, -7.0f, 0.0f, 63.0f, 26.0f, 20.0f, -65.0f, 26.0f, 20.0f, -65.0f, 0.0f, 0.0f,
+};
+
+f32 D_8076D718[] = {
+    0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -50.0f, 40.0f, 40.0f, -50.0f, 40.0f, -40.0f, 0.0f, 1.0f,
+};
+
+f32 D_8076D750[] = {
+    0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, -40.0f, 30.0f, 104.0f, 40.0f, 30.0f, 104.0f, 0.0f, 1.0f,
+};
+
+unk_800CD970 D_8076D788[] = {
+    { 0, 88, 60.0f, D_8076D6C8 }, { 1, 23, 60.0f, D_8076D6E0 },  { 1, 23, 60.0f, D_8076D718 },
+    { 1, 23, 80.0f, D_8076D750 }, { 0, 284, 60.0f, D_8076D6D4 },
+};
+
+const s32 D_80776C90[] = { 0 };
+
+const s32 D_80776C94[] = { 1, 2 };
+
+const s32 D_80776C9C[] = { 5, 7, 6 };
+
+const s32 D_80776CA8[] = { 5, 7, 6, 8 };
+
+const s32* D_8076D7C4[] = {
+    NULL, D_80776C90, D_80776C94, D_80776C9C, D_80776CA8,
+};
+
+ScissorBox D_8076D7D8 = { 12, 8, 308, 232 };
+ScissorBox D_8076D7E8 = { 12, 8, 307, 119 };
+ScissorBox D_8076D7F8 = { 12, 120, 307, 231 };
+ScissorBox D_8076D808 = { 12, 8, 159, 231 };
+ScissorBox D_8076D818 = { 160, 8, 307, 231 };
+ScissorBox D_8076D828 = { 12, 8, 159, 119 };
+ScissorBox D_8076D838 = { 160, 8, 307, 119 };
+ScissorBox D_8076D848 = { 12, 120, 159, 231 };
+ScissorBox D_8076D858 = { 160, 120, 307, 231 };
+ScissorBox D_8076D868 = { 86, 8, 233, 119 };
+ScissorBox D_8076D878 = { 86, 120, 233, 231 };
+ScissorBox D_8076D888 = { 12, 64, 159, 175 };
+ScissorBox D_8076D898 = { 160, 64, 307, 175 };
+
+f32 D_8076D8A8 = 25.4629631f;
+f32 D_8076D8AC = 46.29629517f;
+f32 D_8076D8B0 = 120.0f;
+s32 sMaxCameraLookBackRotate = 8;
+
+void func_80711B20(unk_struct_F8* arg0, unk_struct_20* arg1) {
+    arg0->unk_00 = 1;
+    arg0->unk_04.unk_58.unk_00.unk_00.unk_00 = *arg1;
+}
+
+void func_80711B6C(unk_struct_F8* arg0, unk_redo_1* arg1) {
+    arg0->unk_00 = 1;
+    arg0->unk_04.unk_00 = arg1->unk_00;
+    arg0->unk_04.unk_58.unk_00.unk_00.unk_00 = arg1->unk_58;
+}
+
+void func_80711BF0(unk_struct_F8* arg0, unk_struct_9C* arg1) {
+    arg0->unk_00 = 4;
+    arg0->unk_04.unk_58 = *arg1;
+}
+
+void func_80711C30(unk_struct_F8* arg0, unk_8008112C_arg_1* arg1) {
+    arg0->unk_00 = 4;
+    arg0->unk_04.unk_00 = arg1->unk_00;
+    arg0->unk_04.unk_58 = arg1->unk_58;
+}
+
+void func_80711CA8(unk_struct_F8* arg0, s32 arg1, unk_struct_54* arg2) {
+    arg0->unk_00 = arg1;
+    arg0->unk_04.unk_58.unk_00.unk_00 = *arg2;
+}
+
+void func_80711CE4(unk_struct_F8* arg0, s32 arg1, unk_redo_2* arg2) {
+    arg0->unk_00 = arg1;
+    arg0->unk_04.unk_00 = arg2->unk_00;
+    arg0->unk_04.unk_58.unk_00.unk_00 = arg2->unk_58;
+}
+
+void func_80711D58(unk_struct_F8* arg0, unk_struct_68* arg1) {
+    arg0->unk_00 = 5;
+    arg0->unk_04.unk_58.unk_00 = *arg1;
+}
+
+void func_80711DA4(unk_struct_F8* arg0, unk_redo_3* arg1) {
+    arg0->unk_00 = 5;
+    arg0->unk_04.unk_00 = arg1->unk_00;
+    arg0->unk_04.unk_58.unk_00 = arg1->unk_58;
+}
+
+void func_80711E28(unk_struct_F8* arg0) {
+    f32* var = arg0->unk_04.unk_00.unk_18;
+
+    var[0] += (var[3] - var[0]) * var[6];
+    var[1] += (var[4] - var[1]) * var[6];
+    var[2] += (var[5] - var[2]) * var[6];
+    var[7] += (var[8] - var[7]) * var[9];
+    var[10] += (var[12] - var[10]) * var[14];
+    var[11] += (var[13] - var[11]) * var[15];
+}
+
+// Likely uses the previously defined structs
+void func_80711EDC(unk_struct_F8* arg0) {
+    unk_struct_20* var2 = &arg0->unk_04.unk_58.unk_00.unk_00.unk_00;
+    unk_struct_58* var = &arg0->unk_04.unk_00;
+
+    var->unk_00.x += (var2->unk_00.x - var->unk_00.x) * var2->unk_18;
+    var->unk_00.y += (var2->unk_00.y - var->unk_00.y) * var2->unk_18;
+    var->unk_00.z += (var2->unk_00.z - var->unk_00.z) * var2->unk_18;
+    var->unk_0C.x += (var2->unk_0C.x - var->unk_0C.x) * var2->unk_1C;
+    var->unk_0C.y += (var2->unk_0C.y - var->unk_0C.y) * var2->unk_1C;
+    var->unk_0C.z += (var2->unk_0C.z - var->unk_0C.z) * var2->unk_1C;
+}
+
+void func_80711F90(unk_struct_F8* arg0) {
+    f32 temp_fa0;
+    f32 sp40;
+    f32 sp3C;
+    f32 temp_ft5;
+    f32 temp_fv0;
+    f32 temp_fv1;
+    s32 temp_v0;
+    f32 sp28;
+    unk_struct_58* temp_v0_4;
+    unk_struct_54* temp_v1 = &arg0->unk_04.unk_58.unk_00.unk_00;
+
+    temp_v1->unk_30.x += (temp_v1->unk_30.y - temp_v1->unk_30.x) * temp_v1->unk_30.z;
+    temp_v1->unk_3C.x += (temp_v1->unk_3C.y - temp_v1->unk_3C.x) * temp_v1->unk_3C.z;
+    temp_v1->unk_48.x += (temp_v1->unk_48.y - temp_v1->unk_48.x) * temp_v1->unk_48.z;
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(temp_v1->unk_3C.x));
+
+    sp3C = temp_v1->unk_30.x * SIN(temp_v0);
+    sp40 = temp_v1->unk_30.x * COS(temp_v0);
+
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(temp_v1->unk_48.x));
+    temp_fv0 = SIN(temp_v0) * sp40;
+    temp_fv1 = COS(temp_v0) * sp40;
+
+    temp_fa0 = (temp_v1->unk_00.unk_0C.x * temp_fv1) + (temp_v1->unk_24.x * temp_fv0) + (temp_v1->unk_00.unk_18 * sp3C);
+    temp_ft5 = (temp_v1->unk_00.unk_0C.y * temp_fv1) + (temp_v1->unk_24.y * temp_fv0) + (temp_v1->unk_00.unk_1C * sp3C);
+    sp28 = (temp_v1->unk_00.unk_0C.z * temp_fv1) + (temp_v1->unk_24.z * temp_fv0) + (temp_v1->unk_20 * sp3C);
+
+    temp_v0_4 = &arg0->unk_04.unk_00;
+    switch (arg0->unk_00) {
+        case 2:
+            temp_v0_4->unk_00 = temp_v1->unk_00.unk_00;
+            temp_v0_4->unk_0C.x = temp_v1->unk_00.unk_00.x + temp_fa0;
+            temp_v0_4->unk_0C.y = temp_v1->unk_00.unk_00.y + temp_ft5;
+            temp_v0_4->unk_0C.z = temp_v1->unk_00.unk_00.z + sp28;
+            break;
+        case 3:
+            temp_v0_4->unk_0C = temp_v1->unk_00.unk_00;
+            temp_v0_4->unk_00.x = temp_v1->unk_00.unk_00.x + temp_fa0;
+            temp_v0_4->unk_00.y = temp_v1->unk_00.unk_00.y + temp_ft5;
+            temp_v0_4->unk_00.z = temp_v1->unk_00.unk_00.z + sp28;
+            break;
+    }
+}
+
+extern s32 gNumPlayers;
+extern s8 gGamePaused;
+
+void func_807121D4(unk_struct_F8* arg0, Player* player) {
+    s32 angle;
+    f32 var_fv1;
+    f32 spA4;
+    Vec3f sp98;
+    Vec3f sp8C;
+    Racer* racer = &gRacers[player->id];
+    Vec3f sp7C;
+    Vec3f sp70;
+    f32 temp_fv0;
+    unk_8008112C_arg_1* temp_s1 = &arg0->unk_04;
+    unk_struct_9C* temp_s2 = &arg0->unk_04.unk_58;
+
+    temp_s2->unk_68[1] += (temp_s2->unk_68[2] - temp_s2->unk_68[1]) * temp_s2->unk_68[3];
+    temp_s2->unk_68[4] += (temp_s2->unk_68[5] - temp_s2->unk_68[4]) * temp_s2->unk_68[6];
+    temp_s2->unk_68[7] += (temp_s2->unk_68[8] - temp_s2->unk_68[7]) * temp_s2->unk_68[9];
+
+    player->unk_20.x = racer->unk_180.x;
+    player->unk_20.y = racer->unk_180.y;
+    player->unk_20.z = racer->unk_180.z;
+
+    var_fv1 = (racer->unk_18C.x * racer->unk_A8.x) + (racer->unk_18C.y * racer->unk_A8.y) +
+              (racer->unk_18C.z * racer->unk_A8.z);
+    sp98.x = (temp_s2->unk_00.unk_54.x - player->unk_20.x) + (var_fv1 * racer->unk_A8.x);
+    sp98.y = (temp_s2->unk_00.unk_54.y - player->unk_20.y) + (var_fv1 * racer->unk_A8.y);
+    sp98.z = (temp_s2->unk_00.unk_54.z - player->unk_20.z) + (var_fv1 * racer->unk_A8.z);
+    var_fv1 = sqrtf(SQ(sp98.x) + SQ(sp98.y) + SQ(sp98.z));
+
+    if (var_fv1 < 0.01f) {
+        return;
+    }
+
+    var_fv1 = 1.0f / var_fv1;
+    sp98.x *= var_fv1;
+    sp98.y *= var_fv1;
+    sp98.z *= var_fv1;
+    if (!gGamePaused) {
+        temp_fv0 = temp_s2->unk_68[1];
+        temp_s2->unk_00.unk_54.x = player->unk_20.x + (temp_fv0 * sp98.x);
+        temp_s2->unk_00.unk_54.y = player->unk_20.y + (temp_fv0 * sp98.y);
+        temp_s2->unk_00.unk_54.z = player->unk_20.z + (temp_fv0 * sp98.z);
+    }
+
+    temp_fv0 = (racer->unk_18C.x * player->unk_5C.y.x) + (racer->unk_18C.y * player->unk_5C.y.y) +
+               (racer->unk_18C.z * player->unk_5C.y.z);
+    if (temp_s2->unk_68[8] >= 50.0f) {
+        var_fv1 = 0.0f;
+    } else {
+        var_fv1 = (50.0f - temp_s2->unk_68[8]) * 0.02f;
+    }
+
+    temp_s1->unk_00.unk_00.x = player->unk_20.x + (var_fv1 * (racer->unk_18C.x - (temp_fv0 * player->unk_5C.y.x)));
+    temp_s1->unk_00.unk_00.y = player->unk_20.y + (var_fv1 * (racer->unk_18C.y - (temp_fv0 * player->unk_5C.y.y)));
+    temp_s1->unk_00.unk_00.z = player->unk_20.z + (var_fv1 * (racer->unk_18C.z - (temp_fv0 * player->unk_5C.y.z)));
+    sp8C.x = racer->unk_A8.x - player->unk_2C.y.x;
+    sp8C.y = racer->unk_A8.y - player->unk_2C.y.y;
+    sp8C.z = racer->unk_A8.z - player->unk_2C.y.z;
+
+    var_fv1 = sqrtf(SQ(sp8C.x) + SQ(sp8C.y) + SQ(sp8C.z)) * 0.2f;
+    player->unk_2C.y.x += var_fv1 * sp8C.x;
+    temp_s2->unk_00.unk_00.unk_30.x = player->unk_2C.y.x;
+    player->unk_2C.y.y += var_fv1 * sp8C.y;
+    temp_s2->unk_00.unk_00.unk_30.y = player->unk_2C.y.y;
+    player->unk_2C.y.z += var_fv1 * sp8C.z;
+
+    temp_s2->unk_00.unk_00.unk_30.z = player->unk_2C.y.z;
+    sp7C.x = (temp_s2->unk_00.unk_00.unk_30.y * sp98.z) - (temp_s2->unk_00.unk_00.unk_30.z * sp98.y);
+    sp7C.y = (temp_s2->unk_00.unk_00.unk_30.z * sp98.x) - (temp_s2->unk_00.unk_00.unk_30.x * sp98.z);
+    sp7C.z = (temp_s2->unk_00.unk_00.unk_30.x * sp98.y) - (temp_s2->unk_00.unk_00.unk_30.y * sp98.x);
+    var_fv1 = sqrtf(SQ(sp7C.x) + SQ(sp7C.y) + SQ(sp7C.z));
+    if (var_fv1 < 0.1f) {
+        return;
+    }
+
+    var_fv1 = 1.0f / var_fv1;
+    sp7C.x *= var_fv1;
+    sp7C.y *= var_fv1;
+    sp7C.z *= var_fv1;
+
+    sp70.x = (sp98.y * sp7C.z) - (sp98.z * sp7C.y);
+    sp70.y = (sp98.z * sp7C.x) - (sp98.x * sp7C.z);
+    sp70.z = (sp98.x * sp7C.y) - (sp98.y * sp7C.x);
+
+    var_fv1 = 1.0f / sqrtf(SQ(sp70.x) + SQ(sp70.y) + SQ(sp70.z));
+
+    sp70.x *= var_fv1;
+    sp70.y *= var_fv1;
+    sp70.z *= var_fv1;
+    angle = Math_Round(DEG_TO_FZXANG2(temp_s2->unk_68[4]));
+
+    var_fv1 = temp_s2->unk_68[1] * SIN(angle) *
+              ((sp70.x * racer->unk_C0.y.x) + (sp70.y * racer->unk_C0.y.y) + (sp70.z * racer->unk_C0.y.z));
+    spA4 = temp_s2->unk_68[1] * COS(angle);
+
+    angle = Math_Round(DEG_TO_FZXANG2(temp_s2->unk_68[8]));
+    temp_fv0 = COS(angle) * spA4;
+    spA4 = SIN(angle) * spA4;
+    temp_s1->unk_00.unk_0C.x = player->unk_20.x + (spA4 * sp7C.x) + (temp_fv0 * sp98.x) + (var_fv1 * sp70.x);
+    temp_s1->unk_00.unk_0C.y = player->unk_20.y + (spA4 * sp7C.y) + (temp_fv0 * sp98.y) + (var_fv1 * sp70.y);
+    temp_s1->unk_00.unk_0C.z = player->unk_20.z + (spA4 * sp7C.z) + (temp_fv0 * sp98.z) + (var_fv1 * sp70.z);
+    temp_s2->unk_00.unk_00.unk_24.x = temp_s1->unk_00.unk_00.x - temp_s1->unk_00.unk_0C.x;
+    temp_s2->unk_00.unk_00.unk_24.y = temp_s1->unk_00.unk_00.y - temp_s1->unk_00.unk_0C.y;
+    temp_s2->unk_00.unk_00.unk_24.z = temp_s1->unk_00.unk_00.z - temp_s1->unk_00.unk_0C.z;
+    func_806F6D8C((Mtx3F*) &temp_s2->unk_00.unk_00.unk_24);
+    if (!gGamePaused) {
+        temp_s1->unk_00.unk_18[3] = temp_s1->unk_00.unk_18[0] = temp_s2->unk_00.unk_00.unk_30.x;
+        temp_s1->unk_00.unk_18[4] = temp_s1->unk_00.unk_18[1] = temp_s2->unk_00.unk_00.unk_30.y;
+        temp_s1->unk_00.unk_18[5] = temp_s1->unk_00.unk_18[2] = temp_s2->unk_00.unk_00.unk_30.z;
+    }
+    temp_s1->unk_00.unk_18[10] = 0.0f;
+    temp_s1->unk_00.unk_18[12] = 0.0f;
+    if (gNumPlayers == 2) {
+        temp_s1->unk_00.unk_18[11] = -15.0f;
+        temp_s1->unk_00.unk_18[13] = -15.0f;
+    } else {
+        temp_s1->unk_00.unk_18[11] = 77.0f;
+        temp_s1->unk_00.unk_18[13] = 77.0f;
+    }
+}
+
+void func_80712864(unk_struct_F8* arg0) {
+    unk_struct_58* var = &arg0->unk_04.unk_00;
+    unk_struct_68* var2 = &arg0->unk_04.unk_58.unk_00;
+
+    var2->unk_00.unk_30.x += (var2->unk_00.unk_3C.x - var2->unk_00.unk_30.x) * var2->unk_60;
+    var2->unk_00.unk_30.y += (var2->unk_00.unk_3C.y - var2->unk_00.unk_30.y) * var2->unk_60;
+    var2->unk_00.unk_30.z += (var2->unk_00.unk_3C.z - var2->unk_00.unk_30.z) * var2->unk_60;
+
+    var2->unk_00.unk_48.x += (var2->unk_54.x - var2->unk_00.unk_48.x) * var2->unk_64;
+    var2->unk_00.unk_48.y += (var2->unk_54.y - var2->unk_00.unk_48.y) * var2->unk_64;
+    var2->unk_00.unk_48.z += (var2->unk_54.z - var2->unk_00.unk_48.z) * var2->unk_64;
+
+    var->unk_00.x = var2->unk_00.unk_00.unk_00.x + (var2->unk_00.unk_24.x * var2->unk_00.unk_30.x) +
+                    (var2->unk_00.unk_00.unk_18 * var2->unk_00.unk_30.y) +
+                    (var2->unk_00.unk_00.unk_0C.x * var2->unk_00.unk_30.z);
+    var->unk_00.y = var2->unk_00.unk_00.unk_00.y + (var2->unk_00.unk_24.y * var2->unk_00.unk_30.x) +
+                    (var2->unk_00.unk_00.unk_1C * var2->unk_00.unk_30.y) +
+                    (var2->unk_00.unk_00.unk_0C.y * var2->unk_00.unk_30.z);
+    var->unk_00.z = var2->unk_00.unk_00.unk_00.z + (var2->unk_00.unk_24.z * var2->unk_00.unk_30.x) +
+                    (var2->unk_00.unk_20 * var2->unk_00.unk_30.y) +
+                    (var2->unk_00.unk_00.unk_0C.z * var2->unk_00.unk_30.z);
+
+    var->unk_0C.x = var2->unk_00.unk_00.unk_00.x + (var2->unk_00.unk_24.x * var2->unk_00.unk_48.x) +
+                    (var2->unk_00.unk_00.unk_18 * var2->unk_00.unk_48.y) +
+                    (var2->unk_00.unk_00.unk_0C.x * var2->unk_00.unk_48.z);
+    var->unk_0C.y = var2->unk_00.unk_00.unk_00.y + (var2->unk_00.unk_24.y * var2->unk_00.unk_48.x) +
+                    (var2->unk_00.unk_00.unk_1C * var2->unk_00.unk_48.y) +
+                    (var2->unk_00.unk_00.unk_0C.y * var2->unk_00.unk_48.z);
+    var->unk_0C.z = var2->unk_00.unk_00.unk_00.z + (var2->unk_00.unk_24.z * var2->unk_00.unk_48.x) +
+                    (var2->unk_00.unk_20 * var2->unk_00.unk_48.y) +
+                    (var2->unk_00.unk_00.unk_0C.z * var2->unk_00.unk_48.z);
+}
+
+void func_80712AA8(unk_struct_F8* arg0, Player* player) {
+
+    switch (arg0->unk_00) {
+        case 1:
+            func_80711EDC(arg0);
+            break;
+        case 4:
+            func_807121D4(arg0, player);
+            break;
+        case 2:
+        case 3:
+            func_80711F90(arg0);
+            break;
+        case 5:
+            func_80712864(arg0);
+            break;
+    }
+    func_80711E28(arg0);
+}
+
+void func_80712B34(unk_struct_F8* arg0, Vec3f* arg1, Vec3f* arg2, Vec3f* arg3, f32* arg4) {
+    unk_8008112C_arg_1* temp_v0_3 = &arg0->unk_04;
+    unk_struct_9C* temp_v0 = &arg0->unk_04.unk_58;
+
+    if (arg1 != NULL) {
+        temp_v0->unk_00.unk_00.unk_00.unk_00.x = arg1->x;
+        temp_v0->unk_00.unk_00.unk_00.unk_00.y = arg1->y;
+        temp_v0->unk_00.unk_00.unk_00.unk_00.z = arg1->z;
+    }
+    if (arg2 != NULL) {
+        temp_v0->unk_00.unk_00.unk_00.unk_0C.x = arg2->x;
+        temp_v0->unk_00.unk_00.unk_00.unk_0C.y = arg2->y;
+        temp_v0->unk_00.unk_00.unk_00.unk_0C.z = arg2->z;
+    }
+    if (arg3 != NULL) {
+        temp_v0_3->unk_00.unk_18[3] = arg3->x;
+        temp_v0_3->unk_00.unk_18[4] = arg3->y;
+        temp_v0_3->unk_00.unk_18[5] = arg3->z;
+    }
+    if (arg4 != NULL) {
+        arg0->unk_04.unk_00.unk_18[8] = *arg4;
+    }
+}
+
+void func_80712BBC(unk_struct_F8* arg0, Vec3f* arg1, Vec3f* arg2, Vec3f* arg3, f32* arg4) {
+    unk_8008112C_arg_1* temp_v0_3 = &arg0->unk_04;
+    unk_struct_9C* temp_v0 = &arg0->unk_04.unk_58;
+
+    if (arg1 != NULL) {
+        temp_v0->unk_00.unk_00.unk_00.unk_00.x = arg1->x;
+        temp_v0->unk_00.unk_00.unk_00.unk_00.y = arg1->y;
+        temp_v0->unk_00.unk_00.unk_00.unk_00.z = arg1->z;
+    }
+    if (arg2 != NULL) {
+        temp_v0->unk_00.unk_00.unk_30.y = arg2->x;
+        temp_v0->unk_00.unk_00.unk_48.y = arg2->y;
+        temp_v0->unk_00.unk_00.unk_3C.y = arg2->z;
+    }
+    if (arg3 != NULL) {
+        temp_v0_3->unk_00.unk_18[3] = arg3->x;
+        temp_v0_3->unk_00.unk_18[4] = arg3->y;
+        temp_v0_3->unk_00.unk_18[5] = arg3->z;
+    }
+    if (arg4 != NULL) {
+        arg0->unk_04.unk_00.unk_18[8] = *arg4;
+    }
+}
+
+void func_80712C44(unk_struct_F8* arg0, Vec3f* arg1, Mtx3F* arg2, Vec3f* arg3, Vec3f* arg4, Vec3f* arg5, f32* arg6) {
+    unk_struct_58* temp_v0_4 = &arg0->unk_04.unk_00;
+    unk_struct_68* temp_v0 = &arg0->unk_04.unk_58.unk_00;
+
+    if (arg1 != NULL) {
+        temp_v0->unk_00.unk_00.unk_00.x = arg1->x;
+        temp_v0->unk_00.unk_00.unk_00.y = arg1->y;
+        temp_v0->unk_00.unk_00.unk_00.z = arg1->z;
+    }
+    if (arg2 != NULL) {
+        temp_v0->unk_00.unk_00.unk_0C.x += arg2->x.x * 0.2f;
+        temp_v0->unk_00.unk_00.unk_0C.y += arg2->x.y * 0.2f;
+        temp_v0->unk_00.unk_00.unk_0C.z += arg2->x.z * 0.2f;
+        temp_v0->unk_00.unk_00.unk_18 += arg2->y.x * 0.2f;
+        temp_v0->unk_00.unk_00.unk_1C += arg2->y.y * 0.2f;
+        temp_v0->unk_00.unk_20 += arg2->y.z * 0.2f;
+        temp_v0->unk_00.unk_24.x += arg2->z.x * 0.2f;
+        temp_v0->unk_00.unk_24.y += arg2->z.y * 0.2f;
+        temp_v0->unk_00.unk_24.z += arg2->z.z * 0.2f;
+        func_806F6D8C((Mtx3F*) &temp_v0->unk_00.unk_00.unk_0C);
+    }
+    if (arg3 != NULL) {
+        temp_v0->unk_00.unk_3C.x = arg3->x;
+        temp_v0->unk_00.unk_3C.y = arg3->y;
+        temp_v0->unk_00.unk_3C.z = arg3->z;
+    }
+    if (arg4 != NULL) {
+        temp_v0->unk_54.x = arg4->x;
+        temp_v0->unk_54.y = arg4->y;
+        temp_v0->unk_54.z = arg4->z;
+    }
+    if (arg5 != NULL) {
+        temp_v0_4->unk_18[3] = arg5->x;
+        temp_v0_4->unk_18[4] = arg5->y;
+        temp_v0_4->unk_18[5] = arg5->z;
+    }
+    if (arg6 != NULL) {
+        temp_v0_4->unk_18[8] = *arg6;
+    }
+}
+
+void func_80712DE0(unk_struct_F8* arg0, Vec3f* arg1, Vec3f* arg2, Vec3f* arg3, f32* arg4) {
+    unk_8008112C_arg_1* temp_v0_3 = &arg0->unk_04;
+    unk_struct_9C* temp_v0 = &arg0->unk_04.unk_58;
+
+    if (arg1 != NULL) {
+        temp_v0->unk_00.unk_00.unk_48.x = arg1->x;
+        temp_v0->unk_00.unk_00.unk_48.y = arg1->y;
+        temp_v0->unk_00.unk_00.unk_48.z = arg1->z;
+    }
+    if (arg2 != NULL) {
+        temp_v0->unk_68[2] = arg2->x;
+        temp_v0->unk_68[8] = arg2->y;
+        temp_v0->unk_68[5] = arg2->z;
+    }
+    if (arg3 != NULL) {
+        temp_v0_3->unk_00.unk_18[3] = arg3->x;
+        temp_v0_3->unk_00.unk_18[4] = arg3->y;
+        temp_v0_3->unk_00.unk_18[5] = arg3->z;
+    }
+    if (arg4 != NULL) {
+        arg0->unk_04.unk_00.unk_18[8] = *arg4;
+    }
+}
+
+f32 func_80712E68(CourseSegment** arg0, f32 arg1, f32 arg2) {
+    f32 temp_fs3;
+    s32 i;
+    s32 sp54;
+    s32 pad[4];
+    Vec3f sp80;
+    Mtx3F sp5C;
+
+    sp54 = (s32) arg2 / 20;
+    temp_fs3 = func_i2_800B2824(*arg0, arg1, &sp5C, 0.0f);
+
+    for (i = 0; i < sp54; i++) {
+        arg1 += 20.0f / temp_fs3;
+        if (arg1 >= 1.0f) {
+            *arg0 = (*arg0)->next;
+            arg1 -= 1.0f;
+            arg1 *= (temp_fs3 / func_i2_800B2500(*arg0, 0.0f, &sp80));
+        }
+    }
+
+    arg1 += ((arg2 - ((f32) sp54 * 20.0f)) / temp_fs3);
+    if (arg1 >= 1.0f) {
+        *arg0 = (*arg0)->next;
+        arg1 -= 1.0f;
+        arg1 *= (temp_fs3 / func_i2_800B2500(*arg0, 0.0f, &sp80));
+    }
+    return arg1;
+}
+
+Mtx3F* func_80712FE4(Mtx3F* arg0, CourseSegment* arg1, f32 arg2) {
+    s32 pad;
+    f32 sp40;
+    Mtx3F sp1C;
+
+    func_i2_800B2824(arg1, arg2, &sp1C, func_i2_800B20D0(arg1, arg2, &sp40));
+    *arg0 = sp1C;
+
+    return arg0;
+}
+
+void func_80713064(Player* player, unk_8008112C_arg_1* arg1, unk_struct_9C* arg2, s32 arg3) {
+    Vec3f* var_v0;
+
+    if (arg3 == 2) {
+        var_v0 = &D_80776A78[player->cameraSetting];
+    } else {
+        var_v0 = &D_80776A48[player->cameraSetting];
+    }
+    arg2->unk_68[2] = var_v0->y;
+    arg2->unk_68[5] = var_v0->z;
+    arg1->unk_00.unk_18[8] = player->unk_14 = var_v0->x;
+
+    player->unk_10 = 2;
+
+    switch (player->cameraSetting) {
+        case 1:
+        case 2:
+            player->unk_10 |= 1;
+            break;
+        default:
+            break;
+    }
+}
+
+void func_807130F8(Player* player, unk_struct_F8* arg1) {
+    player->unk_50 = arg1->unk_04.unk_00.unk_0C;
+
+    player->unk_88 = arg1->unk_04.unk_00.unk_00;
+
+    player->unk_5C.y.x = arg1->unk_04.unk_00.unk_18[0];
+    player->unk_5C.y.y = arg1->unk_04.unk_00.unk_18[1];
+    player->unk_5C.y.z = arg1->unk_04.unk_00.unk_18[2];
+    player->unk_94.x = arg1->unk_04.unk_00.unk_18[7];
+    player->unk_94.y = arg1->unk_04.unk_00.unk_18[10];
+    player->unk_94.z = arg1->unk_04.unk_00.unk_18[11];
+}
+
+void func_8071315C(Player* player) {
+    Mtx3F* temp_a0;
+    f32 temp_fv0;
+    f32 temp_fv0_2;
+    f32 temp_fv1;
+
+    player->unk_5C.x.x = player->unk_88.x - player->unk_50.x;
+    player->unk_5C.x.y = player->unk_88.y - player->unk_50.y;
+    player->unk_5C.x.z = player->unk_88.z - player->unk_50.z;
+
+    func_806F6D8C(&player->unk_5C);
+    temp_fv0 = player->unk_5C.x.x;
+    temp_fv1 = player->unk_5C.x.z;
+    temp_fv0_2 = sqrtf(SQ(temp_fv0) + SQ(temp_fv1));
+    if (temp_fv0_2 != 0.0f) {
+        player->unk_80 = (f32) (player->unk_5C.x.x / temp_fv0_2);
+        player->unk_84 = (f32) (player->unk_5C.x.z / temp_fv0_2);
+    }
+}
+
+void func_80713204(MtxF* arg0, MtxF* arg1, MtxF* arg2) {
+    arg0->m[0][0] = (arg1->m[0][0] * arg2->m[0][0]) + (arg1->m[2][0] * arg2->m[0][2]);
+    arg0->m[0][1] = (arg1->m[1][1] * arg2->m[0][1]) + (arg1->m[2][1] * arg2->m[0][2]);
+    arg0->m[0][2] = arg1->m[2][2] * arg2->m[0][2];
+    arg0->m[0][3] = -arg2->m[0][2];
+    arg0->m[1][0] = (arg1->m[0][0] * arg2->m[1][0]) + (arg1->m[2][0] * arg2->m[1][2]);
+    arg0->m[1][1] = (arg1->m[1][1] * arg2->m[1][1]) + (arg1->m[2][1] * arg2->m[1][2]);
+    arg0->m[1][2] = arg1->m[2][2] * arg2->m[1][2];
+    arg0->m[1][3] = -arg2->m[1][2];
+    arg0->m[2][0] = (arg1->m[0][0] * arg2->m[2][0]) + (arg1->m[2][0] * arg2->m[2][2]);
+    arg0->m[2][1] = (arg1->m[1][1] * arg2->m[2][1]) + (arg1->m[2][1] * arg2->m[2][2]);
+    arg0->m[2][2] = arg1->m[2][2] * arg2->m[2][2];
+    arg0->m[2][3] = -arg2->m[2][2];
+    arg0->m[3][0] = (arg1->m[0][0] * arg2->m[3][0]) + (arg1->m[2][0] * arg2->m[3][2]);
+    arg0->m[3][1] = (arg1->m[1][1] * arg2->m[3][1]) + (arg1->m[2][1] * arg2->m[3][2]);
+    arg0->m[3][2] = (arg1->m[2][2] * arg2->m[3][2]) + arg1->m[3][2];
+    arg0->m[3][3] = -arg2->m[3][2];
+}
+
+void func_807133A0(MtxF* mtxF, Mtx* mtx2) {
+    s32 pad[3];
+    s64 var_v1;
+    f32 temp_fv0;
+    s32 i;
+    s32 j;
+    Mtx* mtx = mtx2;
+
+    for (i = 3; i >= 0; i--) {
+        for (j = 3; j >= 0; j--) {
+            temp_fv0 = mtxF->m[i][j] * 65536.0f;
+            if (temp_fv0 < 0.0f) {
+                var_v1 = temp_fv0 - 0.5f;
+            } else {
+                var_v1 = temp_fv0 + 0.5f;
+            }
+
+            mtx->u.i[i][j] = var_v1 >> 0x10;
+            mtx->u.f[i][j] = var_v1 & 0xFFFF;
+        }
+    }
+}
+
+void func_807134AC(GfxPool* arg0, Player* player) {
+    Vec3f sp74;
+    Vec3f sp68;
+    f32 var_fv0;
+    f32 temp_fa0;
+    s32 pad[2];
+
+    func_806F9384(&arg0->unk_1A008[player->id], &player->unk_11C, player->unk_94.x, player->unk_A0, player->unk_A4,
+                  player->unk_A8, player->unk_94.y, player->unk_AC, player->unk_94.z, &player->unk_118);
+    sp68 = player->unk_50;
+    sp74 = player->unk_88;
+
+    func_806F8FE0(&arg0->unk_1A108[player->id], &player->unk_15C, sp68.x, sp68.y, sp68.z, sp74.x, sp74.y, sp74.z,
+                  player->unk_5C.y.x, player->unk_5C.y.y, player->unk_5C.y.z);
+    func_80713204(&player->unk_19C, &player->unk_11C, &player->unk_15C);
+    if (gNumPlayers != 2) {
+        if (player->unk_19C.m[3][1] >= 0.0f) {
+            var_fv0 = player->unk_19C.m[3][1];
+        } else {
+            var_fv0 = -player->unk_19C.m[3][1];
+        }
+        if (var_fv0 > 30000.0f) {
+            var_fv0 -= 30000.0f;
+            var_fv0 /= 2767.0f;
+            if (var_fv0 >= 1.0f) {
+                var_fv0 = 1.0f;
+            }
+            temp_fa0 = player->unk_94.x + ((85.0f - player->unk_94.x) * var_fv0);
+
+            func_806F9384(&arg0->unk_1A008[player->id], &player->unk_11C, temp_fa0, player->unk_A0, player->unk_A4,
+                          player->unk_A8, player->unk_94.y, player->unk_AC, player->unk_94.z, &player->unk_118);
+            func_80713204(&player->unk_19C, &player->unk_11C, &player->unk_15C);
+        }
+    }
+    func_807133A0(&player->unk_19C, &arg0->unk_1A208[player->id]);
+}
+
+extern s32 D_807A16C8;
+
+void func_8071370C(Player* arg0) {
+    Racer* racer;
+    f32 var_fv1;
+    f32 var_fa0;
+    f32 sp20;
+    f32 sp1C;
+    f32 sp18;
+
+    racer = &gRacers[D_807A16C8];
+    sp20 = racer->unk_0C.unk_34.x - arg0->unk_50.x;
+    sp1C = racer->unk_0C.unk_34.y - arg0->unk_50.y;
+    sp18 = racer->unk_0C.unk_34.z - arg0->unk_50.z;
+
+    var_fv1 = sqrtf((sp20 * sp20) + (sp1C * sp1C) + (sp18 * sp18));
+
+    if (var_fv1 != 0.0f) {
+        var_fa0 = -((arg0->unk_5C.z.x * sp20) + (sp1C * arg0->unk_5C.z.y) + (sp18 * arg0->unk_5C.z.z)) / var_fv1;
+        var_fv1 *= var_fa0;
+    }
+    if ((var_fv1 >= -1000.0f) && (var_fv1 <= 1000.0f)) {
+        func_80740BD8(((var_fv1 + 1000.0f) / 2000.0f) * 127.0f);
+    }
+}
+
+void func_807138CC(f32* x, f32* y, f32* z) {
+    f32 normalizeScale;
+
+    normalizeScale = 1.0f / (SQ(*x) + SQ(*y) + SQ(*z));
+    *x *= normalizeScale;
+    *y *= normalizeScale;
+    *z *= normalizeScale;
+}
+
+void func_8071391C(MtxF* mtxF, f32 angle, f32 x, f32 y, f32 z) {
+    s32 pad[2];
+    f32 temp_fa0;
+    f32 temp_ft1;
+    f32 cos;
+    f32 sp18;
+    f32 temp_fv0;
+    f32 sin;
+    s32 temp_v0;
+
+    func_807138CC(&x, &y, &z);
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(angle));
+    sin = SIN(temp_v0);
+    cos = COS(temp_v0);
+    temp_fv0 = 1.0f - cos;
+    temp_ft1 = x * y * temp_fv0;
+    temp_fa0 = y * z * temp_fv0;
+    sp18 = z * x * temp_fv0;
+    mtxF->m[0][0] = ((1.0f - SQ(x)) * cos) + SQ(x);
+    mtxF->m[2][1] = temp_fa0 - (x * sin);
+    mtxF->m[1][2] = (x * sin) + temp_fa0;
+    mtxF->m[1][1] = ((1.0f - SQ(y)) * cos) + SQ(y);
+    mtxF->m[2][0] = (y * sin) + sp18;
+    mtxF->m[0][2] = sp18 - (y * sin);
+    mtxF->m[2][2] = ((1.0f - SQ(z)) * cos) + SQ(z);
+    mtxF->m[1][0] = temp_ft1 - (z * sin);
+    mtxF->m[0][1] = (z * sin) + temp_ft1;
+    mtxF->m[3][3] = 1.0f;
+    mtxF->m[0][3] = mtxF->m[1][3] = mtxF->m[2][3] = mtxF->m[3][0] = mtxF->m[3][1] = mtxF->m[3][2] = 0.0f;
+}
+
+typedef struct unk_800832EC_arg_2 {
+    u32 unk_00;
+    u32 unk_04;
+    s32* unk_08;
+    u8* unk_0C;
+} unk_800832EC_arg_2;
+
+void func_80713AC0(unk_800832EC_arg_2* arg0) {
+    u32 i;
+
+    for (i = 0; i < arg0->unk_04; i++) {
+        arg0->unk_08[i] = 0;
+    }
+}
+
+u8* func_80713B00(u32 arg0, unk_800832EC_arg_2* arg1) {
+    s32 var_v0;
+    u32 temp_a2;
+    u32 temp_v0;
+    s32 var_a0;
+    u32 var_a3;
+
+    if ((arg0 % arg1->unk_00) != 0) {
+        var_v0 = 1;
+    } else {
+        var_v0 = 0;
+    }
+
+    temp_a2 = var_v0 + (arg0 / arg1->unk_00);
+    if (arg1->unk_04 < temp_a2) {
+        return NULL;
+    }
+
+    temp_v0 = (arg1->unk_04 - temp_a2) + 1;
+
+    for (var_a0 = 0; var_a0 < temp_v0; var_a0++) {
+        for (var_a3 = 0; var_a3 < temp_a2; var_a3++) {
+            if (arg1->unk_08[var_a0 + var_a3] != 0) {
+                break;
+            }
+        }
+        if (var_a3 >= temp_a2) {
+            for (var_a3 = 0; var_a3 < temp_a2; var_a3++) {
+                arg1->unk_08[var_a0 + var_a3] = temp_a2 - var_a3;
+            }
+            return &arg1->unk_0C[arg1->unk_00 * var_a0];
+        }
+    }
+    return NULL;
+}
+
+void func_80713C9C(u8* arg0, unk_800832EC_arg_2* arg1) {
+    s32 temp_v1;
+    u32 i;
+    u32 temp_lo;
+
+    if (arg0 != NULL) {
+        temp_lo = (size_t) (arg0 - arg1->unk_0C) / arg1->unk_00;
+        temp_v1 = arg1->unk_08[temp_lo];
+
+        for (i = 0; i < temp_v1; i++) {
+            arg1->unk_08[temp_lo + i] = 0;
+        }
+    }
+}
+
+u8* func_80713D78(u8* arg0, u32 arg1, unk_800832EC_arg_2* arg2) {
+    u8* temp_v0;
+    u32 var_a2;
+    s32 var_v1;
+
+    temp_v0 = func_80713B00(arg1, arg2);
+    if (temp_v0 == NULL) {
+        return NULL;
+    }
+    if (arg0 == NULL) {
+        return temp_v0;
+    }
+    var_v1 = arg2->unk_08[(size_t) (arg0 - arg2->unk_0C) / arg2->unk_00];
+    var_a2 = arg2->unk_00 * var_v1;
+    if (arg1 < var_a2) {
+        var_a2 = arg1;
+    }
+
+    bcopy(arg0, temp_v0, var_a2);
+    func_80713C9C(arg0, arg2);
+    return temp_v0;
+}
+
+extern s32 gGameMode;
+extern GfxPool D_1000000;
+extern Player gPlayers[];
+
+Gfx* func_80713E38(Gfx* gfx, s32 arg1, s32 playerIndex) {
+    Player* player = &gPlayers[playerIndex];
+
+    switch (player->unk_E0) {
+        case 1:
+            gSPViewport(gfx++, &D_1000000.unk_362C8[playerIndex]);
+            gDPSetScissor(gfx++, G_SC_NON_INTERLACE, player->unk_B0, player->unk_B4, player->unk_B8, player->unk_BC);
+            break;
+        default:
+            gfx = func_806F6360(gfx, arg1);
+            if ((gNumPlayers == 1) && (gGameMode != GAMEMODE_RECORDS) && (gGameMode != GAMEMODE_GP_END_CS)) {
+                gDPSetScissor(gfx++, G_SC_NON_INTERLACE, 12, 16, 308, 224);
+            }
+            break;
+    }
+
+    return gfx;
+}
+
+void func_80713F8C(s32 arg0, f32 arg1, f32 arg2, f32 arg3) {
+
+    D_807A10A0[arg0].unk_04.unk_58.unk_68[1] = D_807A10A0[arg0].unk_04.unk_58.unk_68[2] = arg1;
+    D_807A10A0[arg0].unk_04.unk_58.unk_68[4] = D_807A10A0[arg0].unk_04.unk_58.unk_68[5] = arg2;
+    D_807A10A0[arg0].unk_04.unk_58.unk_68[7] = D_807A10A0[arg0].unk_04.unk_58.unk_68[8] = arg3;
+}
+
+void func_80713FD4(unk_800E5D70* arg0, unk_struct_F8* arg1) {
+    arg0->unk_00 = arg1;
+}
+
+void func_80713FDC(unk_800E5D70* arg0, unk_struct_20_2* arg1) {
+    arg0->unk_0C = arg1;
+}
+
+void func_80713FE4(unk_800E5D70* arg0, Vec3f* arg1, Mtx3F* arg2, Racer* arg3) {
+    arg0->unk_10 = arg1;
+    arg0->unk_14 = arg2;
+    arg0->unk_18 = arg3;
+}
+
+void func_80713FF4(unk_800E5D70* arg0, Vec3f* arg1, Mtx3F* arg2) {
+    arg0->unk_1C = arg1;
+    arg0->unk_20 = arg2;
+}
+
+void func_80714000(unk_800E5D70* arg0, unk_struct_C* arg1) {
+    arg0->unk_04 = arg1;
+    arg0->unk_08 = 0;
+}
+
+void func_8071400C(unk_800E5D70* arg0, s32 arg1) {
+    func_80715768(arg0->unk_0C, arg1);
+}
+
+void func_8071402C(unk_800E5D70* arg0, f32* arg1) {
+    arg0->unk_00->unk_04.unk_00.unk_18[13] = *arg1;
+}
+
+bool func_8071403C(unk_800E5D70* arg0) {
+    bool ret;
+    unk_struct_C* var_s0;
+
+    while (true) {
+        ret = false;
+        var_s0 = arg0->unk_04;
+        if (var_s0 == NULL) {
+            return true;
+        }
+
+        if (var_s0->unk_04 != NULL) {
+            ((void (*)(unk_800E5D70*, void*)) var_s0->unk_04)(arg0, var_s0->unk_08);
+        }
+        switch (var_s0->unk_00) {
+            case 0:
+                arg0->unk_04++;
+                continue;
+            case -1:
+                arg0->unk_08 = 0;
+                var_s0 = NULL;
+                ret = true;
+                break;
+            case -2:
+                arg0->unk_08++;
+                ret = true;
+                break;
+            default:
+                if (++arg0->unk_08 >= var_s0->unk_00) {
+                    var_s0++;
+                    arg0->unk_08 = 0;
+                }
+                break;
+        }
+        break;
+    }
+
+    arg0->unk_04 = var_s0;
+    return ret;
+}
+
+void func_80714130(unk_800E5D70* arg0, unk_redo_1* arg1) {
+    func_80711B6C(arg0->unk_00, arg1);
+}
+
+void func_80714150(unk_800E5D70* arg0, unk_redo_2* arg1) {
+    func_80711CE4(arg0->unk_00, 2, arg1);
+}
+
+void func_80714178(unk_800E5D70* arg0, unk_redo_2* arg1) {
+    func_80711CE4(arg0->unk_00, 3, arg1);
+}
+
+void func_807141A0(unk_800E5D70* arg0, unk_8008112C_arg_1* arg1) {
+    func_80711C30(arg0->unk_00, arg1);
+}
+
+void func_807141C0(unk_800E5D70* arg0, unk_redo_3* arg1) {
+    func_80711DA4(arg0->unk_00, arg1);
+}
+
+void func_80083754(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp38[2];
+    Vec3f sp2C;
+
+    func_80715E1C(sp38, arg0->unk_0C, arg1);
+    sp2C.x = sp38[0].x + arg0->unk_10->x;
+    sp2C.y = sp38[0].y + arg0->unk_10->y;
+    sp2C.z = sp38[0].z + arg0->unk_10->z;
+    func_80712B34(arg0->unk_00, &sp2C, &sp38[1], NULL, NULL);
+}
+
+void func_80714268(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp34[3];
+    Vec3f sp28;
+
+    func_80715E60(sp34, arg0->unk_0C, arg1);
+    sp28.x = sp34[0].x + arg0->unk_10->x;
+    sp28.y = sp34[0].y + arg0->unk_10->y;
+    sp28.z = sp34[0].z + arg0->unk_10->z;
+    func_80712B34(arg0->unk_00, &sp28, &sp34[1], &sp34[2], NULL);
+}
+
+void func_807142F0(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    unk_80085434_arg_0 sp34;
+    Vec3f sp28;
+
+    func_80715EC0(&sp34, arg0->unk_0C, arg1);
+    sp28.x = sp34.unk_00[0].x + arg0->unk_10->x;
+    sp28.y = sp34.unk_00[0].y + arg0->unk_10->y;
+    sp28.z = sp34.unk_00[0].z + arg0->unk_10->z;
+    func_80712B34(arg0->unk_00, &sp28, &sp34.unk_00[1], NULL, &sp34.unk_18);
+}
+
+void func_8071437C(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    unk_80085494_arg_0 sp38;
+    Vec3f sp2C;
+
+    func_80715F20(&sp38, arg0->unk_0C, arg1);
+    sp2C.x = sp38.unk_00[0].x + arg0->unk_10->x;
+    sp2C.y = sp38.unk_00[0].y + arg0->unk_10->y;
+    sp2C.z = sp38.unk_00[0].z + arg0->unk_10->z;
+    func_80712B34(arg0->unk_00, &sp2C, &sp38.unk_00[1], &sp38.unk_00[2], &sp38.unk_24);
+}
+
+void func_80714408(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp48[2];
+    Vec3f sp3C;
+    Vec3f sp30;
+
+    func_80715E1C(sp48, arg0->unk_0C, arg1);
+    sp3C.x = sp48[0].x + arg0->unk_10->x;
+    sp3C.y = sp48[0].y + arg0->unk_10->y;
+    sp3C.z = sp48[0].z + arg0->unk_10->z;
+
+    sp30.x =
+        arg0->unk_1C->x + arg0->unk_20->x.x * sp48[1].z + arg0->unk_20->y.x * sp48[1].y + arg0->unk_20->z.x * sp48[1].x;
+    sp30.y =
+        arg0->unk_1C->y + arg0->unk_20->x.y * sp48[1].z + arg0->unk_20->y.y * sp48[1].y + arg0->unk_20->z.y * sp48[1].x;
+    sp30.z =
+        arg0->unk_1C->z + arg0->unk_20->x.z * sp48[1].z + arg0->unk_20->y.z * sp48[1].y + arg0->unk_20->z.z * sp48[1].x;
+    func_80712B34(arg0->unk_00, &sp3C, &sp30, NULL, NULL);
+}
+
+void func_80714538(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp44[3];
+    Vec3f sp38;
+    Vec3f sp2C;
+
+    func_80715E60(sp44, arg0->unk_0C, arg1);
+    sp38.x = sp44[0].x + arg0->unk_10->x;
+    sp38.y = sp44[0].y + arg0->unk_10->y;
+    sp38.z = sp44[0].z + arg0->unk_10->z;
+
+    sp2C.x =
+        arg0->unk_1C->x + arg0->unk_20->x.x * sp44[1].z + arg0->unk_20->y.x * sp44[1].y + arg0->unk_20->z.x * sp44[1].x;
+    sp2C.y =
+        arg0->unk_1C->y + arg0->unk_20->x.y * sp44[1].z + arg0->unk_20->y.y * sp44[1].y + arg0->unk_20->z.y * sp44[1].x;
+    sp2C.z =
+        arg0->unk_1C->z + arg0->unk_20->x.z * sp44[1].z + arg0->unk_20->y.z * sp44[1].y + arg0->unk_20->z.z * sp44[1].x;
+    func_80712B34(arg0->unk_00, &sp38, &sp2C, &sp44[2], NULL);
+}
+
+void func_80714668(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    unk_80085434_arg_0 sp44;
+    Vec3f sp38;
+    Vec3f sp2C;
+
+    func_80715EC0(&sp44, arg0->unk_0C, arg1);
+    sp38.x = sp44.unk_00[0].x + arg0->unk_10->x;
+    sp38.y = sp44.unk_00[0].y + arg0->unk_10->y;
+    sp38.z = sp44.unk_00[0].z + arg0->unk_10->z;
+
+    sp2C.x = arg0->unk_1C->x + arg0->unk_20->x.x * sp44.unk_00[1].z + arg0->unk_20->y.x * sp44.unk_00[1].y +
+             arg0->unk_20->z.x * sp44.unk_00[1].x;
+    sp2C.y = arg0->unk_1C->y + arg0->unk_20->x.y * sp44.unk_00[1].z + arg0->unk_20->y.y * sp44.unk_00[1].y +
+             arg0->unk_20->z.y * sp44.unk_00[1].x;
+    sp2C.z = arg0->unk_1C->z + arg0->unk_20->x.z * sp44.unk_00[1].z + arg0->unk_20->y.z * sp44.unk_00[1].y +
+             arg0->unk_20->z.z * sp44.unk_00[1].x;
+    func_80712B34(arg0->unk_00, &sp38, &sp2C, NULL, &sp44.unk_18);
+}
+
+void func_8071479C(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    unk_80085494_arg_0 sp48;
+    Vec3f sp3C;
+    Vec3f sp30;
+
+    func_80715F20(&sp48, arg0->unk_0C, arg1);
+    sp3C.x = sp48.unk_00[0].x + arg0->unk_10->x;
+    sp3C.y = sp48.unk_00[0].y + arg0->unk_10->y;
+    sp3C.z = sp48.unk_00[0].z + arg0->unk_10->z;
+
+    sp30.x = arg0->unk_1C->x + arg0->unk_20->x.x * sp48.unk_00[1].z + arg0->unk_20->y.x * sp48.unk_00[1].y +
+             arg0->unk_20->z.x * sp48.unk_00[1].x;
+    sp30.y = arg0->unk_1C->y + arg0->unk_20->x.y * sp48.unk_00[1].z + arg0->unk_20->y.y * sp48.unk_00[1].y +
+             arg0->unk_20->z.y * sp48.unk_00[1].x;
+    sp30.z = arg0->unk_1C->z + arg0->unk_20->x.z * sp48.unk_00[1].z + arg0->unk_20->y.z * sp48.unk_00[1].y +
+             arg0->unk_20->z.z * sp48.unk_00[1].x;
+    func_80712B34(arg0->unk_00, &sp3C, &sp30, &sp48.unk_00[2], &sp48.unk_24);
+}
+
+void func_807148D0(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp20[2];
+
+    func_80715E1C(sp20, arg0->unk_0C, arg1);
+    func_80712B34(arg0->unk_00, &sp20[0], &sp20[1], NULL, NULL);
+}
+
+void func_8071491C(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp24[3];
+
+    func_80715E60(sp24, arg0->unk_0C, arg1);
+    func_80712B34(arg0->unk_00, &sp24[0], &sp24[1], &sp24[2], NULL);
+}
+
+void func_80714968(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    unk_80085434_arg_0 sp24;
+
+    func_80715EC0(&sp24, arg0->unk_0C, arg1);
+    func_80712B34(arg0->unk_00, &sp24.unk_00[0], &sp24.unk_00[1], NULL, &sp24.unk_18);
+}
+
+void func_807149B8(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    unk_80085494_arg_0 sp20;
+
+    func_80715F20(&sp20, arg0->unk_0C, arg1);
+    func_80712B34(arg0->unk_00, &sp20.unk_00[0], &sp20.unk_00[1], &sp20.unk_00[2], &sp20.unk_24);
+}
+
+void func_80714A08(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp20[2];
+
+    func_80715E1C(sp20, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp20[0], &sp20[1], NULL, NULL);
+}
+
+void func_80714A54(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp24[3];
+
+    func_80715E60(sp24, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp24[0], &sp24[1], &sp24[2], NULL);
+}
+
+void func_80714AA0(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    unk_80085434_arg_0 sp24;
+
+    func_80715EC0(&sp24, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp24.unk_00[0], &sp24.unk_00[1], NULL, &sp24.unk_18);
+}
+
+void func_80714AF0(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    unk_80085494_arg_0 sp20;
+
+    func_80715F20(&sp20, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp20.unk_00[0], &sp20.unk_00[1], &sp20.unk_00[2], &sp20.unk_24);
+}
+
+void func_80714B40(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp20[2];
+
+    func_80715E1C(sp20, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp20[1], &sp20[0], NULL, NULL);
+}
+
+void func_80714B8C(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    Vec3f sp24[3];
+
+    func_80715E60(sp24, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp24[1], &sp24[0], &sp24[2], NULL);
+}
+
+void func_80714BD8(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    unk_80085434_arg_0 sp24;
+
+    func_80715EC0(&sp24, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp24.unk_00[1], &sp24.unk_00[0], NULL, &sp24.unk_18);
+}
+
+void func_80714C28(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    unk_80085494_arg_0 sp20;
+
+    func_80715F20(&sp20, arg0->unk_0C, arg1);
+    func_80712BBC(arg0->unk_00, &sp20.unk_00[1], &sp20.unk_00[0], &sp20.unk_00[2], &sp20.unk_24);
+}
+
+void func_80714C78(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    s32 sp64;
+    s32 temp_v0;
+    f32 sp5C;
+    f32 sp58;
+    f32 temp_fv0;
+    Vec3f sp3C[2];
+    Vec3f sp30;
+    s32 pad;
+
+    func_80715E1C(sp3C, arg0->unk_0C, arg1);
+    //! @bug uninitialised angles
+    sp64 = Math_Round(DEG_TO_FZXANG2(sp5C));
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(sp58));
+    temp_fv0 = COS(temp_v0) * sp3C[0].x;
+    sp30.x = COS(sp64) * temp_fv0 + arg0->unk_10->x;
+    sp30.y = sp3C[0].x * SIN(temp_v0) + arg0->unk_10->y;
+    sp30.z = arg0->unk_10->z - SIN(sp64) * temp_fv0;
+    func_80712BBC(arg0->unk_00, &sp30, &sp3C[1], NULL, NULL);
+}
+
+void func_80714D90(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    s32 sp6C;
+    s32 temp_v0;
+    f32 sp64;
+    f32 sp60;
+    f32 temp_fv0;
+    Vec3f sp38[3];
+    Vec3f sp2C;
+    s32 pad;
+
+    func_80715E60(sp38, arg0->unk_0C, arg1);
+    //! @bug uninitialised angles
+    sp6C = Math_Round(DEG_TO_FZXANG2(sp64));
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(sp60));
+    temp_fv0 = COS(temp_v0) * sp38[0].x;
+    sp2C.x = COS(sp6C) * temp_fv0 + arg0->unk_10->x;
+    sp2C.y = sp38[0].x * SIN(temp_v0) + arg0->unk_10->y;
+    sp2C.z = arg0->unk_10->z - SIN(sp6C) * temp_fv0;
+    func_80712BBC(arg0->unk_00, &sp2C, &sp38[1], &sp38[2], NULL);
+}
+
+void func_80714EA8(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    s32 sp64;
+    s32 temp_v0;
+    f32 sp5C;
+    f32 sp58;
+    f32 temp_fv0;
+    unk_80085434_arg_0 sp38;
+    Vec3f sp2C;
+    s32 pad;
+
+    func_80715EC0(&sp38, arg0->unk_0C, arg1);
+    //! @bug uninitialised angles
+    sp64 = Math_Round(DEG_TO_FZXANG2(sp5C));
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(sp58));
+    temp_fv0 = COS(temp_v0) * sp38.unk_00[0].x;
+    sp2C.x = COS(sp64) * temp_fv0 + arg0->unk_10->x;
+    sp2C.y = sp38.unk_00[0].x * SIN(temp_v0) + arg0->unk_10->y;
+    sp2C.z = arg0->unk_10->z - SIN(sp64) * temp_fv0;
+    func_80712BBC(arg0->unk_00, &sp2C, &sp38.unk_00[1], NULL, &sp38.unk_18);
+}
+
+void func_80714FC4(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    s32 sp74;
+    s32 temp_v0;
+    f32 sp6C;
+    f32 sp68;
+    f32 temp_fv0;
+    unk_80085494_arg_0 sp3C;
+    Vec3f sp30;
+    s32 pad;
+
+    func_80715F20(&sp3C, arg0->unk_0C, arg1);
+    //! @bug uninitialised angles
+    sp74 = Math_Round(DEG_TO_FZXANG2(sp6C));
+    temp_v0 = Math_Round(DEG_TO_FZXANG2(sp68));
+    temp_fv0 = COS(temp_v0) * sp3C.unk_00[0].x;
+    sp30.x = COS(sp74) * temp_fv0 + arg0->unk_10->x;
+    sp30.y = sp3C.unk_00[0].x * SIN(temp_v0) + arg0->unk_10->y;
+    sp30.z = arg0->unk_10->z - SIN(sp74) * temp_fv0;
+    func_80712BBC(arg0->unk_00, &sp30, &sp3C.unk_00[1], &sp3C.unk_00[2], &sp3C.unk_24);
+}
+
+void func_807150E0(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    s32 pad;
+    Vec3f sp64[2];
+    Vec3f sp58;
+    Mtx3F sp34;
+
+    func_80715E1C(sp64, arg0->unk_0C, arg1->unk_00);
+    sp58.x = arg0->unk_10->x;
+    sp58.y = arg0->unk_10->y;
+    sp58.z = arg0->unk_10->z;
+    sp34 = *arg0->unk_14;
+    func_80712C44(arg0->unk_00, &sp58, &sp34, &sp64[0], &sp64[1], NULL, NULL);
+}
+
+void func_8071518C(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    s32 pad;
+    Vec3f sp60[3];
+    Vec3f sp54;
+    Mtx3F sp30;
+
+    func_80715E60(sp60, arg0->unk_0C, arg1);
+    sp54.x = arg0->unk_10->x;
+    sp54.y = arg0->unk_10->y;
+    sp54.z = arg0->unk_10->z;
+    sp30 = *arg0->unk_14;
+    func_80712C44(arg0->unk_00, &sp54, &sp30, &sp60[0], &sp60[1], &sp60[2], NULL);
+}
+
+void func_8071523C(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    s32 pad;
+    unk_80085434_arg_0 sp60;
+    Vec3f sp54;
+    Mtx3F sp30;
+
+    func_80715EC0(&sp60, arg0->unk_0C, arg1);
+    sp54.x = arg0->unk_10->x;
+    sp54.y = arg0->unk_10->y;
+    sp54.z = arg0->unk_10->z;
+    sp30 = *arg0->unk_14;
+    func_80712C44(arg0->unk_00, &sp54, &sp30, &sp60.unk_00[0], &sp60.unk_00[1], NULL, &sp60.unk_18);
+}
+
+void func_807152EC(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    s32 pad;
+    unk_80085494_arg_0 sp64;
+    Vec3f sp58;
+    Mtx3F sp34;
+
+    func_80715F20(&sp64, arg0->unk_0C, arg1);
+    sp58.x = arg0->unk_10->x;
+    sp58.y = arg0->unk_10->y;
+    sp58.z = arg0->unk_10->z;
+    sp34 = *arg0->unk_14;
+    func_80712C44(arg0->unk_00, &sp58, &sp34, &sp64.unk_00[0], &sp64.unk_00[1], &sp64.unk_00[2], &sp64.unk_24);
+}
+
+// TODO: sort out unk_struct_20 and unk_struct_68 (conflicting struct copies)
+void func_807153A0(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    s32 pad[4];
+    unk_struct_9C* temp_v0;
+    Racer* temp_v1;
+    Vec3f sp38[2];
+    Vec3f sp2C;
+
+    func_80715E1C(sp38, arg0->unk_0C, arg1);
+    temp_v1 = arg0->unk_18;
+    temp_v0 = &arg0->unk_00->unk_04.unk_58;
+    *((Mtx3F*) &temp_v0->unk_00.unk_00.unk_00) = *arg0->unk_14;
+    *((Vec3f*) &temp_v0->unk_00.unk_60) = temp_v1->unk_B4;
+    temp_v0->unk_90 = temp_v1->speed;
+    temp_v0->unk_98 = temp_v1->unk_0C.courseSegment->trackSegmentInfo;
+    sp2C.x = sp38[0].x + arg0->unk_10->x;
+    sp2C.y = sp38[0].y + arg0->unk_10->y;
+    sp2C.z = sp38[0].z + arg0->unk_10->z;
+
+    func_80712DE0(arg0->unk_00, &sp2C, &sp38[1], 0, 0);
+}
+
+void func_80715490(unk_800E5D70* arg0, unk_struct_14* arg1) {
+    s32 pad[4];
+    unk_struct_9C* temp_v0;
+    Racer* temp_v1;
+    Vec3f sp34[3];
+    Vec3f sp28;
+
+    func_80715E60(sp34, arg0->unk_0C, arg1);
+    temp_v1 = arg0->unk_18;
+    temp_v0 = &arg0->unk_00->unk_04.unk_58;
+    *((Mtx3F*) &temp_v0->unk_00.unk_00.unk_00) = *arg0->unk_14;
+    *((Vec3f*) &temp_v0->unk_00.unk_60) = temp_v1->unk_B4;
+    temp_v0->unk_90 = temp_v1->speed;
+    temp_v0->unk_98 = temp_v1->unk_0C.courseSegment->trackSegmentInfo;
+    sp28.x = sp34[0].x + arg0->unk_10->x;
+    sp28.y = sp34[0].y + arg0->unk_10->y;
+    sp28.z = sp34[0].z + arg0->unk_10->z;
+
+    func_80712DE0(arg0->unk_00, &sp28, &sp34[1], &sp34[2], 0);
+}
+
+void func_80715580(unk_800E5D70* arg0, unk_80085434_arg_2* arg1) {
+    s32 pad[6];
+    unk_struct_9C* temp_v0;
+    Racer* temp_v1;
+    unk_80085434_arg_0 sp34;
+    Vec3f sp28;
+
+    func_80715EC0(&sp34, arg0->unk_0C, arg1);
+    temp_v1 = arg0->unk_18;
+    temp_v0 = &arg0->unk_00->unk_04.unk_58;
+    *((Mtx3F*) &temp_v0->unk_00.unk_00.unk_00) = *arg0->unk_14;
+    *((Vec3f*) &temp_v0->unk_00.unk_60) = temp_v1->unk_B4;
+    temp_v0->unk_90 = temp_v1->speed;
+    temp_v0->unk_98 = temp_v1->unk_0C.courseSegment->trackSegmentInfo;
+    sp28.x = sp34.unk_00[0].x + arg0->unk_10->x;
+    sp28.y = sp34.unk_00[0].y + arg0->unk_10->y;
+    sp28.z = sp34.unk_00[0].z + arg0->unk_10->z;
+
+    func_80712DE0(arg0->unk_00, &sp28, &sp34.unk_00[1], 0, &sp34.unk_18);
+}
+
+void func_80715674(unk_800E5D70* arg0, unk_80085494_arg_2* arg1) {
+    s32 pad[4];
+    unk_struct_9C* temp_v0;
+    Racer* temp_v1;
+    unk_80085494_arg_0 sp38;
+    Vec3f sp2C;
+
+    func_80715F20(&sp38, arg0->unk_0C, arg1);
+    temp_v1 = arg0->unk_18;
+    temp_v0 = &arg0->unk_00->unk_04.unk_58;
+    *((Mtx3F*) &temp_v0->unk_00.unk_00.unk_00) = *arg0->unk_14;
+    *((Vec3f*) &temp_v0->unk_00.unk_60) = temp_v1->unk_B4;
+    temp_v0->unk_90 = temp_v1->speed;
+    temp_v0->unk_98 = temp_v1->unk_0C.courseSegment->trackSegmentInfo;
+    sp2C.x = sp38.unk_00[0].x + arg0->unk_10->x;
+    sp2C.y = sp38.unk_00[0].y + arg0->unk_10->y;
+    sp2C.z = sp38.unk_00[0].z + arg0->unk_10->z;
+
+    func_80712DE0(arg0->unk_00, &sp2C, &sp38.unk_00[1], &sp38.unk_00[2], &sp38.unk_24);
+}
+
+void func_80715768(unk_struct_20_2* arg0, s32 arg1) {
+    s32 i;
+
+    for (i = 0; i < arg1; i++) {
+        arg0->unk_00[i].unk_04 = 0;
+        arg0->unk_00[i].unk_00 = 0;
+    }
+}
+
+f32 func_807157DC(f32 arg0, s32 arg1, f32* arg2, s32 arg3) {
+    s32 pad[2];
+    f32 temp_fa1;
+    f32 temp_fv0;
+    f32 temp_fv1;
+    f32 sp10;
+    f32 spC;
+    f32 sp8;
+    f32 sp4;
+
+    if (arg1 == 0) {
+        temp_fv0 = 1.0f - arg0;
+        temp_fv1 = SQ(arg0);
+        sp4 = CB(temp_fv0);
+        temp_fa1 = temp_fv1 * arg0;
+        sp8 = (((temp_fa1 * 21.0f) / 12.0f) - (temp_fv1 * 9.0f / 2.0f)) + (arg0 * 3.0f);
+        spC = ((-temp_fa1 * 11.0f) / 12.0f) + (temp_fv1 * 3.0f / 2.0f);
+        sp10 = temp_fa1 / 6.0f;
+    } else if (arg1 == 1) {
+        temp_fv0 = 1.0f - arg0;
+        temp_fv1 = SQ(arg0);
+        sp4 = CB(temp_fv0) / 4.0f;
+        temp_fa1 = temp_fv1 * arg0;
+        sp8 = (((temp_fa1 * 7.0f) / 12.0f) - (temp_fv1 * 5.0f / 4.0f)) + (arg0 / 4.0f) + 7.0f / 12.0f;
+        spC = (-temp_fa1 / 2.0f) + (temp_fv1 / 2.0f) + (arg0 / 2.0f) + 1.0f / 6.0f;
+        sp10 = temp_fa1 / 6.0f;
+    } else if ((arg3 < 7) || (arg1 < (arg3 - 5))) {
+        temp_fv0 = 1.0f - arg0;
+        temp_fv1 = SQ(arg0);
+        temp_fa1 = temp_fv1 * arg0;
+        sp4 = CB(temp_fv0) / 6.0f;
+        sp8 = ((temp_fa1 / 2.0f) - temp_fv1) + 2.0f / 3.0f;
+        spC = (-temp_fa1 / 2.0f) + (temp_fv1 / 2.0f) + (arg0 / 2.0f) + 1.0f / 6.0f;
+        sp10 = temp_fa1 / 6.0f;
+    } else if (arg1 == arg3 - 5) {
+        temp_fv0 = 1.0f - arg0;
+        temp_fv1 = temp_fv0 * temp_fv0;
+        temp_fa1 = temp_fv1 * temp_fv0;
+        sp4 = temp_fa1 / 6.0f;
+        sp8 = (-temp_fa1 / 2.0f) + (temp_fv1 / 2.0f) + (temp_fv0 / 2.0f) + 1.0f / 6.0f;
+        spC = (((temp_fa1 * 7.0f) / 12.0f) - (temp_fv1 * 5.0f / 4.0f)) + (temp_fv0 / 4.0f) + 7.0f / 12.0f;
+        sp10 = CB(arg0) / 4.0f;
+    } else if (arg1 == arg3 - 4) {
+        temp_fv0 = 1.0f - arg0;
+        temp_fv1 = temp_fv0 * temp_fv0;
+        temp_fa1 = temp_fv1 * temp_fv0;
+        sp4 = temp_fa1 / 6.0f;
+        sp8 = ((-temp_fa1 * 11.0f) / 12.0f) + (temp_fv1 * 3.0f / 2.0f);
+        spC = (((temp_fa1 * 21.0f) / 12.0f) - (temp_fv1 * 9.0f / 2.0f)) + (temp_fv0 * 3.0f);
+        sp10 = CB(arg0);
+    }
+
+    return sp4 * arg2[arg1] + sp8 * arg2[arg1 + 1] + spC * arg2[arg1 + 2] + sp10 * arg2[arg1 + 3];
+}
+
+void func_80715BE0(f32* arg0, unk_struct_8* arg1, unk_80085154_arg_2* arg2) {
+    s32 temp_s0;
+    s32 temp_t2;
+    s32 temp_t6;
+    s32 temp_t9;
+    s32 var_s0;
+    s32 var_v0;
+
+    while (arg2->unk_08[arg1->unk_04] == 0) {
+        arg1->unk_04++;
+    }
+
+    *arg0 =
+        func_807157DC((f32) arg1->unk_00 / (f32) arg2->unk_08[arg1->unk_04], arg1->unk_04, arg2->unk_04, arg2->unk_00);
+
+    arg1->unk_00++;
+
+    if (arg1->unk_00 >= arg2->unk_08[arg1->unk_04]) {
+        arg1->unk_00 = 0;
+        arg1->unk_04++;
+        if (arg1->unk_04 >= (arg2->unk_00 - 3)) {
+            arg1->unk_04 = -1;
+        }
+    }
+}
+
+void func_80715CD8(Vec3f* arg0, unk_struct_8* arg1, unk_struct_14* arg2) {
+    s32 temp_s0;
+    s32 temp_t2;
+    s32 temp_t6;
+    s32 temp_t9;
+    s32 var_s0;
+    s32 var_v0;
+    s32 i;
+
+    while (arg2->unk_10[arg1->unk_04] == 0) {
+        arg1->unk_04++;
+    }
+
+    for (i = 0; i < 3; i++) {
+        arg0->v[i] = func_807157DC((f32) arg1->unk_00 / (f32) arg2->unk_10[arg1->unk_04], arg1->unk_04, arg2->unk_04[i],
+                                   arg2->unk_00);
+    }
+
+    arg1->unk_00++;
+
+    if (arg1->unk_00 >= arg2->unk_10[arg1->unk_04]) {
+        arg1->unk_00 = 0;
+        arg1->unk_04++;
+        if (arg1->unk_04 >= (arg2->unk_00 - 3)) {
+            arg1->unk_04 = -1;
+        }
+    }
+}
+
+void func_80715E1C(Vec3f* arg0, unk_struct_20_2* arg1, unk_struct_14* arg2) {
+    func_80715CD8(&arg0[0], &arg1->unk_00[0], &arg2[0]);
+    func_80715CD8(&arg0[1], &arg1->unk_00[1], &arg2[1]);
+}
+
+void func_80715E60(Vec3f* arg0, unk_struct_20_2* arg1, unk_struct_14* arg2) {
+    func_80715CD8(&arg0[0], &arg1->unk_00[0], &arg2[0]);
+    func_80715CD8(&arg0[1], &arg1->unk_00[1], &arg2[1]);
+    func_80715CD8(&arg0[2], &arg1->unk_00[2], &arg2[2]);
+}
+
+void func_80715EC0(unk_80085434_arg_0* arg0, unk_struct_20_2* arg1, unk_80085434_arg_2* arg2) {
+    func_80715CD8(&arg0->unk_00[0], &arg1->unk_00[0], &arg2->unk_00[0]);
+    func_80715CD8(&arg0->unk_00[1], &arg1->unk_00[1], &arg2->unk_00[1]);
+    func_80715BE0(&arg0->unk_18, &arg1->unk_00[2], &arg2->unk_28);
+}
+
+void func_80715F20(unk_80085494_arg_0* arg0, unk_struct_20_2* arg1, unk_80085494_arg_2* arg2) {
+    func_80715CD8(&arg0->unk_00[0], &arg1->unk_00[0], &arg2->unk_00[0]);
+    func_80715CD8(&arg0->unk_00[1], &arg1->unk_00[1], &arg2->unk_00[1]);
+    func_80715CD8(&arg0->unk_00[2], &arg1->unk_00[2], &arg2->unk_00[2]);
+    func_80715BE0(&arg0->unk_24, &arg1->unk_00[3], &arg2->unk_3C);
+}
+
+void func_80715F9C(void) {
+    unk_800E5D70* var_s1;
+    s32 i;
+    Racer* temp_a3;
+    Player* var_s0;
+    unk_struct_20_2* var_s4;
+    unk_struct_F8* var_s3;
+
+    for (i = 0, var_s0 = gPlayers, var_s1 = D_807A1480, var_s3 = D_807A10A0, var_s4 = D_807A1510; i < 4; i++) {
+        var_s0->id = (s16) i;
+        var_s0->cameraSetting = 2;
+        var_s0->unk_E0 = 0;
+        func_80713FD4(var_s1, var_s3);
+        func_80713FDC(var_s1, var_s4);
+        temp_a3 = &gRacers[var_s0->id];
+        func_80713FE4(var_s1, &temp_a3->unk_180, &temp_a3->unk_C0, temp_a3);
+
+        var_s1++;
+        var_s3++;
+        var_s4++;
+        var_s0++;
+    }
+    D_807A159A = 1;
+}
+
+extern s8 D_8076C7D8;
+
+// FAKE! Very hacky tricks to get 1 to load into v0
+void func_807160A0(void) {
+    s32 i;
+    Player* var_s0;
+    Racer* temp_a3;
+    s32 v0;
+
+    D_807A1594 = 0;
+
+    for (i = 0, var_s0 = gPlayers; i < 4; i++, var_s0++) {
+        temp_a3 = &gRacers[var_s0->id];
+        func_80713FE4(&D_807A1480[i], &temp_a3->unk_180, &temp_a3->unk_C0, temp_a3);
+    }
+    switch (gGameMode) {
+        case GAMEMODE_FLX_TITLE:
+            v0 = 0;
+            if (1) {}
+            D_807A1590 = ++v0;
+            gPlayers[0].unk_04 = 0;
+            func_807166B8(gPlayers, D_807A10A0, D_807A1480);
+            break;
+        case GAMEMODE_CREATE_MACHINE:
+        case GAMEMODE_FLX_MACHINE_SELECT:
+            v0 = 0;
+            if (1) {}
+            D_807A1590 = ++v0;
+            gPlayers[0].unk_04 = v0;
+            func_807166B8(gPlayers, D_807A10A0, D_807A1480);
+            break;
+        case GAMEMODE_LX_MACHINE_SETTINGS:
+        case GAMEMODE_LX_GP_RACE_NEXT_MACHINE_SETTINGS:
+            v0 = 0;
+            if (1) {}
+            D_807A1590 = ++v0;
+            gPlayers[0].unk_04 = 2;
+            func_807166B8(gPlayers, D_807A10A0, D_807A1480);
+            break;
+        case GAMEMODE_FLX_COURSE_SELECT:
+        case GAMEMODE_FLX_GP_RACE_NEXT_COURSE:
+        case GAMEMODE_FLX_RECORDS_COURSE_SELECT:
+            v0 = 0;
+            if (1) {}
+            D_807A1590 = ++v0;
+            gPlayers[0].unk_04 = 3;
+            func_807166B8(gPlayers, D_807A10A0, D_807A1480);
+            break;
+        case GAMEMODE_GP_RACE:
+        case GAMEMODE_PRACTICE:
+        case GAMEMODE_DEATH_RACE:
+        case GAMEMODE_VS_2P:
+        case GAMEMODE_VS_3P:
+        case GAMEMODE_VS_4P:
+            D_8076D6C0 = -1;
+            D_807A1590 = gNumPlayers;
+            for (i = 0; i < D_807A1590; i++) {
+                if (D_8076C7D8 != 0) {
+                    gPlayers[i].unk_04 = 15;
+                } else {
+                    gPlayers[i].unk_04 = 4;
+                }
+
+                gPlayers[i].unk_20 = gRacers[i].unk_0C.unk_34;
+
+                gPlayers[i].unk_2C = gRacers[i].unk_C0;
+
+                func_807166B8(&gPlayers[i], &D_807A10A0[i], &D_807A1480[i]);
+            }
+
+            break;
+        case GAMEMODE_TIME_ATTACK:
+            v0 = 0;
+            if (1) {}
+            D_8076D6C0 = -1;
+            if (D_8076C7D8 != 0) {
+                D_807A1590 = ++v0;
+                gPlayers[0].unk_04 = 15;
+            } else {
+                D_807A1590 = 2;
+                gPlayers[0].unk_04 = 4;
+            }
+            gPlayers[0].unk_20 = gRacers[0].unk_0C.unk_34;
+            gPlayers[0].unk_2C = gRacers[0].unk_C0;
+
+            gPlayers[1].unk_04 = 12;
+            for (i = 0; i < D_807A1590; i++) {
+                func_807166B8(&gPlayers[i], &D_807A10A0[i], &D_807A1480[i]);
+            }
+            break;
+        case GAMEMODE_COURSE_EDIT:
+            v0 = 0;
+            if (1) {}
+            D_807A1590 = ++v0;
+            gPlayers[0].unk_04 = 6;
+
+            gPlayers[0].unk_20 = gRacers[0].unk_0C.unk_34;
+            gPlayers[0].unk_2C = gRacers[0].unk_C0;
+
+            for (i = 0; i < D_807A1590; i++) {
+                func_807166B8(&gPlayers[i], &D_807A10A0[i], &D_807A1480[i]);
+            }
+            break;
+        case GAMEMODE_RECORDS:
+
+            D_807A1590 = 2;
+            gPlayers[0].unk_04 = 0xB;
+            gPlayers[0].unk_20 = gRacers[0].unk_0C.unk_34;
+            gPlayers[0].unk_2C = gRacers[0].unk_C0;
+            gPlayers[1].unk_04 = 0xC;
+            for (i = 0; i < D_807A1590; i++) {
+                func_807166B8(&gPlayers[i], &D_807A10A0[i], &D_807A1480[i]);
+            }
+            break;
+        case GAMEMODE_GP_END_CS:
+            v0 = 0;
+            if (1) {}
+            D_807A1590 = ++v0;
+            gPlayers[0].unk_04 = 0xE;
+            func_807166B8(gPlayers, D_807A10A0, D_807A1480);
+            break;
+    }
+}
+
+extern s16 gPlayer1OverallPosition;
+
+void func_807166B8(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    s32 pad;
+    s32 sp48;
+    bool sp44;
+    f32 angle;
+    s32 pad2;
+    Vec3f* sp38;
+    Vec3f sp2C;
+    Racer* racer;
+
+    player->cameraLookBackRotate = 0;
+    player->unk_18 = 0;
+    player->unk_1C = 0;
+    sp44 = false;
+
+    switch (player->unk_04) {
+        case 1:
+        case 12:
+            player->unk_A0 = 16.0f;
+            player->unk_A4 = 8192.0f;
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            func_80711CE4(arg1, 2, &D_807766A8);
+            break;
+        case 2:
+            player->unk_A0 = 16.0f;
+            player->unk_A4 = 8192.0f;
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            func_80711CE4(arg1, 2, &D_80776754);
+            if (gNumPlayers >= 2) {
+                arg1->unk_04.unk_58.unk_00.unk_00.unk_48.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_48.y = 30.0f;
+            }
+            break;
+        case 3:
+            player->unk_A0 = 16.0f;
+            player->unk_A4 = 16384.0f;
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            func_80711CE4(arg1, 2, &D_80776800);
+            break;
+        case 4:
+            func_80711CE4(arg1, 2, &D_8077699C);
+            if (gNumPlayers == 2) {
+                player->unk_A0 = 16.0f;
+                player->unk_A4 = 8192.0f;
+                arg1->unk_04.unk_00.unk_18[11] = arg1->unk_04.unk_00.unk_18[13] = -15.0f;
+                arg1->unk_04.unk_00.unk_18[7] = arg1->unk_04.unk_00.unk_18[8] = 100.0f;
+            } else {
+                player->unk_A0 = 16.0f;
+                player->unk_A4 = 8192.0f;
+            }
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            sp44 = 1;
+            break;
+        case 6:
+        case 15:
+            if (D_8076C7D8 != 0) {
+                sp48 = 2;
+            } else {
+                sp48 = player->cameraSetting;
+            }
+            if (gNumPlayers == 2) {
+                player->unk_A0 = 16.0f;
+                player->unk_A4 = 8192.0f;
+                player->unk_A8 = 320.0f;
+                player->unk_AC = 240.0f;
+
+                func_80711C30(arg1, &D_80776B9C);
+
+                sp38 = &D_80776A78[sp48];
+            } else {
+                player->unk_A0 = 16.0f;
+                player->unk_A4 = 8192.0f;
+                player->unk_A8 = 320.0f;
+                player->unk_AC = 240.0f;
+
+                func_80711C30(arg1, &D_80776AA8);
+
+                sp38 = &D_80776A48[sp48];
+            }
+            arg1->unk_04.unk_58.unk_68[2] = arg1->unk_04.unk_58.unk_68[1] = sp38->y;
+            arg1->unk_04.unk_58.unk_68[5] = arg1->unk_04.unk_58.unk_68[4] = sp38->z;
+            arg1->unk_04.unk_00.unk_18[8] = arg1->unk_04.unk_00.unk_18[7] = sp38->x;
+
+            Math_Round(DEG_TO_FZXANG2(arg1->unk_04.unk_58.unk_68[4]));
+            racer = &gRacers[player->id];
+            arg1->unk_04.unk_58.unk_00.unk_54.x = racer->unk_180.x - (sp38->y * racer->unk_C0.x.x);
+            arg1->unk_04.unk_58.unk_00.unk_54.y = racer->unk_180.y - (sp38->y * racer->unk_C0.x.y);
+            arg1->unk_04.unk_58.unk_00.unk_54.z = racer->unk_180.z - (sp38->y * racer->unk_C0.x.z);
+            player->unk_14 = arg1->unk_04.unk_00.unk_18[8];
+            player->unk_10 = 0;
+            if ((sp48 == 1) || (sp48 == 2)) {
+                player->unk_10 |= 1;
+            }
+            sp44 = true;
+            break;
+        case 7:
+            sp2C = arg1->unk_04.unk_00.unk_0C;
+            func_80711B6C(arg1, &D_807763D0);
+            arg1->unk_04.unk_00.unk_18[7] = arg1->unk_04.unk_00.unk_18[8] = 80.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_0C = sp2C;
+            if (gNumPlayers == 2) {
+                arg1->unk_04.unk_00.unk_18[11] = arg1->unk_04.unk_00.unk_18[13] = -50.0f;
+            }
+            break;
+        case 8:
+            func_80711B6C(arg1, &D_807763D0);
+            arg1->unk_04.unk_00.unk_18[8] = D_8076D788[0].unk_04;
+            if (gNumPlayers == 2) {
+                arg1->unk_04.unk_00.unk_18[11] = arg1->unk_04.unk_00.unk_18[13] = -30.0f;
+            }
+
+            racer = &gRacers[player->id];
+            func_80718F58(&D_807A15A0[player->id], racer->unk_0C.courseSegment, racer->unk_0C.unk_04, &D_8076D788[0]);
+            break;
+        case 9:
+            racer = &gRacers[player->id];
+
+            func_80711CE4(arg1, 2, &D_80776448);
+            if (gNumPlayers == 2) {
+                arg1->unk_04.unk_00.unk_18[11] = arg1->unk_04.unk_00.unk_18[13] = -30.0f;
+            }
+            arg1->unk_04.unk_00.unk_18[7] = arg1->unk_04.unk_00.unk_18[8] = 80.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_30.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_30.y = 125.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.y = 35.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_48.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_48.y = -50.0f;
+
+            *(Mtx3F*) &arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_0C = racer->unk_C0;
+
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_18 = racer->unk_B4.x;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_1C = racer->unk_B4.y;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_20 = racer->unk_B4.z;
+            break;
+        case 10:
+            sp2C = arg1->unk_04.unk_00.unk_0C;
+            func_80711B6C(arg1, &D_807763D0);
+            arg1->unk_04.unk_00.unk_18[7] = arg1->unk_04.unk_00.unk_18[8] = 80.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_0C = sp2C;
+            break;
+        case 11:
+            player->unk_A0 = 16.0f;
+            player->unk_A4 = 8192.0f;
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            func_80711C30(arg1, &D_80776AA8);
+            arg1->unk_04.unk_58.unk_68[2] = arg1->unk_04.unk_58.unk_68[1] = D_80776A48[1].y;
+            arg1->unk_04.unk_58.unk_68[5] = arg1->unk_04.unk_58.unk_68[4] = 15.0f;
+            arg1->unk_04.unk_00.unk_18[8] = arg1->unk_04.unk_00.unk_18[7] = D_80776A48[1].x;
+            angle = 15.0f;
+            sp38 = &D_80776A48[1];
+            Math_Round(DEG_TO_FZXANG2(angle));
+            racer = &gRacers[0];
+            arg1->unk_04.unk_58.unk_00.unk_54.x = racer->unk_180.x - (sp38->y * racer->unk_C0.x.x);
+            arg1->unk_04.unk_58.unk_00.unk_54.y = racer->unk_180.y - (sp38->y * racer->unk_C0.x.y);
+            arg1->unk_04.unk_58.unk_00.unk_54.z = racer->unk_180.z - (sp38->y * racer->unk_C0.x.z);
+            player->unk_14 = arg1->unk_04.unk_00.unk_18[8];
+            player->unk_10 = 0;
+            sp44 = true;
+            break;
+        case 13:
+            player->unk_A0 = 512.0f;
+            player->unk_A4 = 8192.0f;
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            func_80711B6C(arg1, &D_807768AC);
+            break;
+        case 14:
+            player->unk_A0 = 16.0f;
+            player->unk_A4 = 8192.0f;
+            player->unk_A8 = 320.0f;
+            player->unk_AC = 240.0f;
+            func_80711CE4(arg1, 3, &D_80776448);
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_00.x = 196.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_00.y = 25.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_00.z = -3000.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_30.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_30.y = 258.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.y = -7.0f;
+            arg1->unk_04.unk_58.unk_00.unk_00.unk_48.x = arg1->unk_04.unk_58.unk_00.unk_00.unk_48.y = 269.0f;
+            sp44 = true;
+            if (gPlayer1OverallPosition < 4) {
+                D_807A1598 = gPlayer1OverallPosition - 1;
+            } else {
+                D_807A1598 = 0;
+            }
+            break;
+    }
+    if (sp44) {
+        player->unk_E0 = 0;
+        player->unk_E4 = player->unk_E6 = 0;
+        func_80716F38(player);
+    }
+}
+
+extern s32 D_807A1590;
+
+void func_80716F38(Player* player) {
+    s32* temp = D_8076D7C4[D_807A1590];
+    s32 temp2 = temp[player->id];
+    Vp* sp24;
+    ScissorBox* sp20;
+
+    switch (temp2) {
+        case 0:
+            sp24 = Segment_SegmentedToVirtual(&D_80146A8);
+            sp20 = &D_8076D7D8;
+            break;
+        case 1:
+            sp24 = Segment_SegmentedToVirtual(&D_80146B8);
+            sp20 = &D_8076D7E8;
+            break;
+        case 2:
+            sp24 = Segment_SegmentedToVirtual(&D_80146C8);
+            sp20 = &D_8076D7F8;
+            break;
+        case 3:
+            sp24 = Segment_SegmentedToVirtual(&D_80146D8);
+            sp20 = &D_8076D808;
+            break;
+        case 4:
+            sp24 = Segment_SegmentedToVirtual(&D_80146E8);
+            sp20 = &D_8076D818;
+            break;
+        case 5:
+            sp24 = Segment_SegmentedToVirtual(&D_80146F8);
+            sp20 = &D_8076D828;
+            break;
+        case 6:
+            sp24 = Segment_SegmentedToVirtual(&D_8014708);
+            sp20 = &D_8076D838;
+            break;
+        case 7:
+            sp24 = Segment_SegmentedToVirtual(&D_8014718);
+            sp20 = &D_8076D848;
+            break;
+        case 8:
+            sp24 = Segment_SegmentedToVirtual(&D_8014728);
+            sp20 = &D_8076D858;
+            break;
+        case 9:
+            sp24 = Segment_SegmentedToVirtual(&D_8014738);
+            sp20 = &D_8076D868;
+            break;
+        case 10:
+            sp24 = Segment_SegmentedToVirtual(&D_8014748);
+            sp20 = &D_8076D878;
+            break;
+        case 11:
+            sp24 = Segment_SegmentedToVirtual(&D_8014758);
+            sp20 = &D_8076D888;
+            break;
+        case 12:
+            sp24 = Segment_SegmentedToVirtual(&D_8014768);
+            sp20 = &D_8076D898;
+            break;
+    }
+
+    player->unk_E8 = player->unk_F8 = player->unk_108 = sp24->vp.vscale[0] * 0.25f;
+    player->unk_EC = player->unk_FC = player->unk_10C = sp24->vp.vscale[1] * 0.25f;
+
+    player->unk_F0 = sp24->vp.vtrans[0] * 0.25f;
+    player->unk_F4 = sp24->vp.vtrans[1] * 0.25f;
+
+    player->unk_100 = player->unk_110 = player->unk_F0 - player->unk_E8;
+    player->unk_104 = player->unk_114 = player->unk_F4 - player->unk_EC;
+
+    player->unk_B0 = player->unk_C0 = player->unk_D0 = sp20->left;
+    player->unk_B4 = player->unk_C4 = player->unk_D4 = sp20->top;
+    player->unk_B8 = player->unk_C8 = player->unk_D8 = sp20->right;
+    player->unk_BC = player->unk_CC = player->unk_DC = sp20->bottom;
+}
+
+void func_80717294(void) {
+    s32 i;
+
+    for (i = 0; i < D_807A1590; i++) {
+        func_80717354(&gPlayers[i], &D_807A10A0[i], &D_807A1480[i]);
+    }
+
+    if ((gGameMode == GAMEMODE_VS_2P) || (gGameMode == GAMEMODE_VS_3P) || (gGameMode == GAMEMODE_VS_4P)) {
+        func_80717B20();
+    }
+}
+
+extern GfxPool* gGfxPool;
+
+void func_80717354(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    f32 temp_fa0;
+    f32 temp_fa1;
+    f32 temp_ft4;
+    f32 temp_fv0;
+    f32 var_fv1;
+    f32 var_fv1_2;
+    f32 var_fv1_3;
+    f32 var_fv1_4;
+    bool var_v0;
+    u32 temp_s4;
+    u32 var_v1;
+
+    do {
+        temp_s4 = var_v1 = player->unk_04;
+        switch (var_v1) {
+            case 0:
+            case 1:
+            case 2:
+            case 16:
+            default:
+                break;
+            case 3:
+                func_80718964(player, arg1);
+                break;
+            case 4:
+                if (!gGamePaused) {
+                    func_807181F8(player, arg1);
+                }
+                break;
+            case 5:
+
+                var_v0 = true;
+
+                temp_fv0 = arg1->unk_04.unk_00.unk_18[8] - arg1->unk_04.unk_00.unk_18[7];
+                if (ABS(temp_fv0) > 0.5f) {
+                    var_v0 = false;
+                }
+
+                temp_fv0 = arg1->unk_04.unk_00.unk_18[13] - arg1->unk_04.unk_00.unk_18[11];
+                if (ABS(temp_fv0) > 0.5f) {
+                    var_v0 = false;
+                }
+
+                temp_fv0 = arg1->unk_04.unk_58.unk_68[2] - arg1->unk_04.unk_58.unk_68[1];
+                if (ABS(temp_fv0) > 0.5f) {
+                    var_v0 = false;
+                }
+
+                temp_fv0 = arg1->unk_04.unk_58.unk_68[5] - arg1->unk_04.unk_58.unk_68[4];
+                if (ABS(temp_fv0) > 0.5f) {
+                    var_v0 = false;
+                }
+
+                if (var_v0) {
+                    player->unk_04 = 6;
+                    arg1->unk_04.unk_00.unk_18[9] = 0.2f;
+                    arg1->unk_04.unk_00.unk_18[6] = 1.0f;
+                    arg1->unk_04.unk_00.unk_18[14] = 0.1f;
+                    arg1->unk_04.unk_00.unk_18[15] = 0.2f;
+                    arg1->unk_04.unk_58.unk_68[3] = 0.2f;
+                    arg1->unk_04.unk_58.unk_68[6] = 0.2f;
+                }
+                break;
+            case 6:
+                func_80718530(player, arg1, arg2);
+                break;
+            case 15:
+                func_80718908(player, arg1, arg2);
+                break;
+            case 7:
+                if (!gGamePaused) {
+                    func_80718AB0(player, arg1);
+                }
+                break;
+            case 8:
+                if (!gGamePaused) {
+                    func_80718AFC(player, arg1, arg2);
+                }
+                break;
+            case 9:
+                if (!gGamePaused) {
+                    func_807191B0(player, arg1, arg2);
+                }
+                break;
+            case 10:
+                if (!gGamePaused) {
+                    func_80719140(player, arg1, arg2);
+                }
+                break;
+            case 11:
+                func_80719420(player, arg1, arg2);
+                break;
+            case 14:
+                func_80719480(player, arg1, arg2);
+                break;
+        }
+        var_v1 = player->unk_04;
+    } while (temp_s4 != var_v1);
+
+    func_80712AA8(arg1, player);
+    func_807176B4(player, arg1);
+    func_807130F8(player, arg1);
+    func_8071315C(player);
+    func_807134AC(gGfxPool, player);
+    if ((gGameMode == GAMEMODE_GP_RACE) || (gGameMode == GAMEMODE_PRACTICE) || (gGameMode == GAMEMODE_TIME_ATTACK) ||
+        (gGameMode == GAMEMODE_DEATH_RACE)) {
+        func_8071370C(player);
+    }
+}
+
+void func_807176B4(Player* player, unk_struct_F8* arg1) {
+    Vec3f* var_s1;
+    s32 angle;
+    f32 temp1;
+    f32 temp2;
+    f32 temp3;
+    Mtx3F sp48;
+    f32 temp_fv0;
+    f32 temp_fv1;
+    unk_8008112C_arg_1* temp_v1 = &arg1->unk_04;
+    Racer* temp_s0;
+
+    if (player->unk_04 == 4) {
+        if (gNumPlayers == 2) {
+            var_s1 = &D_80776A78[2];
+        } else {
+            var_s1 = &D_80776A48[2];
+        }
+
+        temp_s0 = &gRacers[player->id];
+
+        sp48.x.x = 0.0f - (var_s1->y * temp_s0->unk_C0.x.x);
+        sp48.x.y = 0.0f - (var_s1->y * temp_s0->unk_C0.x.y);
+        sp48.x.z = 0.0f - (var_s1->y * temp_s0->unk_C0.x.z);
+        temp_fv1 = 1.0f / sqrtf(SQ(sp48.x.x) + SQ(sp48.x.y) + SQ(sp48.x.z));
+        sp48.x.x *= temp_fv1;
+        sp48.x.y *= temp_fv1;
+        sp48.x.z *= temp_fv1;
+
+        sp48.z.x = (temp_s0->unk_C0.y.y * sp48.x.z) - (temp_s0->unk_C0.y.z * sp48.x.y);
+        sp48.z.y = (temp_s0->unk_C0.y.z * sp48.x.x) - (temp_s0->unk_C0.y.x * sp48.x.z);
+        sp48.z.z = (temp_s0->unk_C0.y.x * sp48.x.y) - (temp_s0->unk_C0.y.y * sp48.x.x);
+        temp_fv1 = 1.0f / sqrtf(SQ(sp48.z.x) + SQ(sp48.z.y) + SQ(sp48.z.z));
+        sp48.z.x *= temp_fv1;
+        sp48.z.y *= temp_fv1;
+        sp48.z.z *= temp_fv1;
+
+        sp48.y.x = (sp48.x.y * sp48.z.z) - (sp48.x.z * sp48.z.y);
+        sp48.y.y = (sp48.x.z * sp48.z.x) - (sp48.x.x * sp48.z.z);
+        sp48.y.z = (sp48.x.x * sp48.z.y) - (sp48.x.y * sp48.z.x);
+        temp_fv1 = 1.0f / sqrtf(SQ(sp48.y.x) + SQ(sp48.y.y) + SQ(sp48.y.z));
+        sp48.y.x *= temp_fv1;
+        sp48.y.y *= temp_fv1;
+        sp48.y.z *= temp_fv1;
+
+        angle = Math_Round(DEG_TO_FZXANG2(var_s1->z));
+
+        temp_fv0 = (SIN(angle) * var_s1->y) * ((sp48.y.x * temp_s0->unk_C0.y.x) + (sp48.y.y * temp_s0->unk_C0.y.y) +
+                                               (sp48.y.z * temp_s0->unk_C0.y.z));
+        temp_fv1 = COS(angle) * var_s1->y;
+
+        temp1 = (temp_s0->unk_180.x + (temp_fv1 * sp48.x.x) + (temp_fv0 * sp48.y.x));
+        temp2 = (temp_s0->unk_180.y + (temp_fv1 * sp48.x.y) + (temp_fv0 * sp48.y.y));
+        temp3 = (temp_s0->unk_180.z + (temp_fv1 * sp48.x.z) + (temp_fv0 * sp48.y.z));
+
+        temp_fv0 = (f32) (player->unk_1C - 1) / 300.0f;
+
+        temp_fv0 = (-2.0f * temp_fv0 * temp_fv0 * temp_fv0) + (3.0f * temp_fv0 * temp_fv0);
+
+        temp_v1->unk_00.unk_0C.x = ((1.0f - temp_fv0) * temp_v1->unk_00.unk_0C.x) + (temp_fv0 * temp1);
+        temp_v1->unk_00.unk_0C.y = ((1.0f - temp_fv0) * temp_v1->unk_00.unk_0C.y) + (temp_fv0 * temp2);
+        temp_v1->unk_00.unk_0C.z = ((1.0f - temp_fv0) * temp_v1->unk_00.unk_0C.z) + (temp_fv0 * temp3);
+
+        sp48.x.x = temp_v1->unk_00.unk_00.x - temp_v1->unk_00.unk_0C.x;
+        sp48.x.y = temp_v1->unk_00.unk_00.y - temp_v1->unk_00.unk_0C.y;
+        sp48.x.z = temp_v1->unk_00.unk_00.z - temp_v1->unk_00.unk_0C.z;
+        sp48.y.x = temp_s0->unk_C0.y.x;
+        sp48.y.y = temp_s0->unk_C0.y.y;
+        sp48.y.z = temp_s0->unk_C0.y.z;
+        func_806F6D8C(&sp48);
+        temp_v1->unk_00.unk_18[3] = sp48.y.x;
+        temp_v1->unk_00.unk_18[0] = temp_v1->unk_00.unk_18[3];
+        temp_v1->unk_00.unk_18[4] = sp48.y.y;
+        temp_v1->unk_00.unk_18[1] = temp_v1->unk_00.unk_18[4];
+        temp_v1->unk_00.unk_18[5] = sp48.y.z;
+        temp_v1->unk_00.unk_18[2] = temp_v1->unk_00.unk_18[5];
+    }
+}
+
+extern s32 D_8006D544;
+extern s32 D_8006D548;
+extern s32 D_800BF040;
+extern s32 D_807A1590;
+extern s16 D_807A16CC;
+
+void func_80717B20(void) {
+    Racer* var_a1;
+    f32 temp_fv0;
+    s32 i;
+    Player* var_a0;
+    Vp* vp;
+
+    if (D_8076D6C0 == -1) {
+        if ((D_807A16CC != 0) && (D_8006D544 != 0)) {
+            D_800BF040 = 30;
+
+            for (i = 0, var_a0 = gPlayers; i < D_807A1590; i++, var_a0++) {
+                var_a1 = &gRacers[i];
+                if (var_a1->position == 1) {
+                    D_8076D6C0 = i;
+                }
+                var_a0->unk_E0 = 1;
+                var_a0->unk_E4 = 0;
+                var_a0->unk_E6 = 0x1E;
+            }
+
+            switch (gGameMode) {
+                case GAMEMODE_VS_2P:
+                    if (D_8076D6C0 == 0) {
+                        gPlayers[0].unk_D4 = 8.0f;
+                        gPlayers[0].unk_DC = 231.0f;
+                        gPlayers[0].unk_10C = 120.0f;
+                        gPlayers[0].unk_114 = 0.0f;
+                        gPlayers[1].unk_D4 = 231.0f;
+                        gPlayers[1].unk_DC = 231.0f;
+                        gPlayers[1].unk_10C = 0.0f;
+                        gPlayers[1].unk_114 = 240.0f;
+                    } else {
+                        gPlayers[0].unk_D4 = 8.0f;
+                        gPlayers[0].unk_DC = 8.0f;
+                        gPlayers[0].unk_10C = 0.0f;
+                        gPlayers[0].unk_114 = 0.0f;
+                        gPlayers[1].unk_D4 = 8.0f;
+                        gPlayers[1].unk_DC = 231.0f;
+                        gPlayers[1].unk_10C = 120.0f;
+                        gPlayers[1].unk_114 = 0.0f;
+                    }
+                    break;
+                case GAMEMODE_VS_3P:
+                case GAMEMODE_VS_4P:
+                    switch (D_8076D6C0) {
+                        case 0:
+                            gPlayers[0].unk_D0 = 12.0f;
+                            gPlayers[0].unk_D4 = 8.0f;
+                            gPlayers[0].unk_D8 = 307.0f;
+                            gPlayers[0].unk_DC = 231.0f;
+                            gPlayers[0].unk_108 = 160.0f;
+                            gPlayers[0].unk_10C = 120.0f;
+                            gPlayers[0].unk_110 = 0.0f;
+                            gPlayers[0].unk_114 = 0.0f;
+                            gPlayers[1].unk_D0 = 12.0f;
+                            gPlayers[1].unk_D4 = 231.0f;
+                            gPlayers[1].unk_D8 = 307.0f;
+                            gPlayers[1].unk_DC = 231.0f;
+                            gPlayers[1].unk_108 = 160.0f;
+                            gPlayers[1].unk_10C = 0.0f;
+                            gPlayers[1].unk_110 = 0.0f;
+                            gPlayers[1].unk_114 = 240.0f;
+                            gPlayers[2].unk_D0 = 307.0f;
+                            gPlayers[2].unk_D4 = 8.0f;
+                            gPlayers[2].unk_DC = 231.0f;
+                            gPlayers[2].unk_D8 = 307.0f;
+                            gPlayers[2].unk_108 = 0.0f;
+                            gPlayers[2].unk_10C = 120.0f;
+                            gPlayers[2].unk_110 = 320.0f;
+                            gPlayers[2].unk_114 = 0.0f;
+                            gPlayers[3].unk_D0 = 307.0f;
+                            gPlayers[3].unk_D4 = 231.0f;
+                            gPlayers[3].unk_D8 = 307.0f;
+                            gPlayers[3].unk_DC = 231.0f;
+                            gPlayers[3].unk_108 = 0.0f;
+                            gPlayers[3].unk_10C = 0.0f;
+                            gPlayers[3].unk_110 = 320.0f;
+                            gPlayers[3].unk_114 = 240.0f;
+                            break;
+                        case 1:
+                            gPlayers[0].unk_D0 = 12.0f;
+                            gPlayers[0].unk_D4 = 8.0f;
+                            gPlayers[0].unk_D8 = 307.0f;
+                            gPlayers[0].unk_DC = 8.0f;
+                            gPlayers[0].unk_108 = 160.0f;
+                            gPlayers[0].unk_10C = 0.0f;
+                            gPlayers[0].unk_110 = 0.0f;
+                            gPlayers[0].unk_114 = 0.0f;
+                            gPlayers[1].unk_D0 = 12.0f;
+                            gPlayers[1].unk_D4 = 8.0f;
+                            gPlayers[1].unk_D8 = 307.0f;
+                            gPlayers[1].unk_DC = 231.0f;
+                            gPlayers[1].unk_108 = 160.0f;
+                            gPlayers[1].unk_10C = 120.0f;
+                            gPlayers[1].unk_110 = 0.0f;
+                            gPlayers[1].unk_114 = 0.0f;
+                            gPlayers[2].unk_D0 = 307.0f;
+                            gPlayers[2].unk_D4 = 8.0f;
+                            gPlayers[2].unk_D8 = 307.0f;
+                            gPlayers[2].unk_DC = 8.0f;
+                            gPlayers[2].unk_108 = 0.0f;
+                            gPlayers[2].unk_10C = 0.0f;
+                            gPlayers[2].unk_110 = 320.0f;
+                            gPlayers[2].unk_114 = 0.0f;
+                            gPlayers[3].unk_D0 = 307.0f;
+                            gPlayers[3].unk_D4 = 8.0f;
+                            gPlayers[3].unk_D8 = 307.0f;
+                            gPlayers[3].unk_DC = 231.0f;
+                            gPlayers[3].unk_108 = 0.0f;
+                            gPlayers[3].unk_10C = 120.0f;
+                            gPlayers[3].unk_110 = 320.0f;
+                            gPlayers[3].unk_114 = 0.0f;
+                            break;
+                        case 2:
+                            gPlayers[0].unk_D0 = 12.0f;
+                            gPlayers[0].unk_D4 = 8.0f;
+                            gPlayers[0].unk_D8 = 12.0f;
+                            gPlayers[0].unk_DC = 231.0f;
+                            gPlayers[0].unk_108 = 0.0f;
+                            gPlayers[0].unk_10C = 120.0f;
+                            gPlayers[0].unk_110 = 0.0f;
+                            gPlayers[0].unk_114 = 0.0f;
+                            gPlayers[1].unk_D0 = 12.0f;
+                            gPlayers[1].unk_D4 = 231.0f;
+                            gPlayers[1].unk_D8 = 12.0f;
+                            gPlayers[1].unk_DC = 231.0f;
+                            gPlayers[1].unk_108 = 0.0f;
+                            gPlayers[1].unk_10C = 0.0f;
+                            gPlayers[1].unk_110 = 0.0f;
+                            gPlayers[1].unk_114 = 240.0f;
+                            gPlayers[2].unk_D0 = 12.0f;
+                            gPlayers[2].unk_D4 = 8.0f;
+                            gPlayers[2].unk_D8 = 307.0f;
+                            gPlayers[2].unk_DC = 231.0f;
+                            gPlayers[2].unk_108 = 160.0f;
+                            gPlayers[2].unk_10C = 120.0f;
+                            gPlayers[2].unk_110 = 0.0f;
+                            gPlayers[2].unk_114 = 0.0f;
+                            gPlayers[3].unk_D0 = 12.0f;
+                            gPlayers[3].unk_D4 = 231.0f;
+                            gPlayers[3].unk_D8 = 307.0f;
+                            gPlayers[3].unk_DC = 231.0f;
+                            gPlayers[3].unk_108 = 160.0f;
+                            gPlayers[3].unk_10C = 0.0f;
+                            gPlayers[3].unk_110 = 0.0f;
+                            gPlayers[3].unk_114 = 240.0f;
+                            break;
+                        case 3:
+                            gPlayers[0].unk_108 = 0.0f;
+                            gPlayers[0].unk_10C = 0.0f;
+                            gPlayers[0].unk_D0 = 12.0f;
+                            gPlayers[0].unk_D8 = 12.0f;
+                            gPlayers[0].unk_110 = 0.0f;
+                            gPlayers[0].unk_114 = 0.0f;
+                            gPlayers[0].unk_D4 = 8.0f;
+                            gPlayers[0].unk_DC = 8.0f;
+                            gPlayers[1].unk_D0 = 12.0f;
+                            gPlayers[1].unk_D8 = 12.0f;
+                            gPlayers[2].unk_D0 = 12.0f;
+                            gPlayers[3].unk_D0 = 12.0f;
+                            gPlayers[1].unk_D4 = 8.0f;
+                            gPlayers[2].unk_D4 = 8.0f;
+                            gPlayers[2].unk_DC = 8.0f;
+                            gPlayers[3].unk_D4 = 8.0f;
+                            gPlayers[1].unk_10C = 120.0f;
+                            gPlayers[3].unk_10C = 120.0f;
+                            gPlayers[1].unk_DC = 231.0f;
+                            gPlayers[3].unk_DC = 231.0f;
+                            gPlayers[2].unk_108 = 160.0f;
+                            gPlayers[3].unk_108 = 160.0f;
+                            gPlayers[2].unk_D8 = 307.0f;
+                            gPlayers[3].unk_D8 = 307.0f;
+                            gPlayers[1].unk_108 = 0.0f;
+                            gPlayers[1].unk_110 = 0.0f;
+                            gPlayers[1].unk_114 = 0.0f;
+                            gPlayers[2].unk_10C = 0.0f;
+                            gPlayers[2].unk_110 = 0.0f;
+                            gPlayers[2].unk_114 = 0.0f;
+                            gPlayers[3].unk_110 = 0.0f;
+                            gPlayers[3].unk_114 = 0.0f;
+                            break;
+                    }
+                    break;
+            }
+        }
+    } else if ((gPlayers[D_8076D6C0].unk_E4 == 0x1E) && (D_8006D548 == 0)) {
+        D_8006D548 = 1;
+    }
+
+    for (i = 0, var_a0 = gPlayers; i < D_807A1590; i++, var_a0++) {
+        if (var_a0->unk_E0 == 1) {
+            if (var_a0->unk_E4 < var_a0->unk_E6) {
+                var_a0->unk_E4++;
+            }
+
+            temp_fv0 = (f32) var_a0->unk_E4 / var_a0->unk_E6;
+
+            var_a0->unk_B0 = var_a0->unk_C0 + ((var_a0->unk_D0 - var_a0->unk_C0) * temp_fv0);
+            var_a0->unk_B4 = var_a0->unk_C4 + ((var_a0->unk_D4 - var_a0->unk_C4) * temp_fv0);
+
+            var_a0->unk_B8 = var_a0->unk_C8 + ((var_a0->unk_D8 - var_a0->unk_C8) * temp_fv0);
+            var_a0->unk_BC = var_a0->unk_CC + ((var_a0->unk_DC - var_a0->unk_CC) * temp_fv0);
+            var_a0->unk_E8 = var_a0->unk_F8 + ((var_a0->unk_108 - var_a0->unk_F8) * temp_fv0);
+            var_a0->unk_EC = var_a0->unk_FC + ((var_a0->unk_10C - var_a0->unk_FC) * temp_fv0);
+            var_a0->unk_F0 = var_a0->unk_100 + ((var_a0->unk_110 - var_a0->unk_100) * temp_fv0) + var_a0->unk_E8;
+            var_a0->unk_F4 = var_a0->unk_104 + ((var_a0->unk_114 - var_a0->unk_104) * temp_fv0) + var_a0->unk_EC;
+
+            vp = &gGfxPool->unk_362C8[i];
+            vp->vp.vscale[0] = var_a0->unk_E8 * 4.0f;
+            vp->vp.vscale[1] = var_a0->unk_EC * 4.0f;
+            vp->vp.vscale[2] = 0x1FF;
+            vp->vp.vscale[3] = 0;
+            vp->vp.vtrans[0] = var_a0->unk_F0 * 4.0f;
+            vp->vp.vtrans[1] = var_a0->unk_F4 * 4.0f;
+            vp->vp.vtrans[2] = 0x1FF;
+            vp->vp.vtrans[3] = 0;
+        }
+    }
+}
+
+void func_807181F8(Player* player, unk_struct_F8* arg1) {
+    Vec3f* var_v1;
+    f32 temp_fv0;
+    s32 index;
+    unk_8008112C_arg_1* temp_a0 = &arg1->unk_04;
+    Racer* temp_t3 = &gRacers[player->id];
+    unk_struct_9C* temp_a3 = &arg1->unk_04.unk_58;
+    Racer* temp_t4;
+    s32 pad[5];
+
+    temp_a3->unk_00.unk_00.unk_00.unk_00 = temp_t3->unk_180;
+
+    *((Mtx3F*) &arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_0C) = temp_t3->unk_C0;
+
+    temp_fv0 = (f32) player->unk_1C / 300.0f;
+    temp_fv0 = (-2.0f * temp_fv0 * temp_fv0 * temp_fv0) + (3.0f * temp_fv0 * temp_fv0);
+    arg1->unk_04.unk_58.unk_00.unk_00.unk_30.y = (-880.0f * temp_fv0) + 1000.0f;
+    arg1->unk_04.unk_58.unk_00.unk_00.unk_48.y = (-360.0f * temp_fv0) + 180.0f;
+
+    if (player->unk_1C >= 0x12C) {
+        if (gNumPlayers == 2) {
+            func_80711BF0(arg1, &D_80776B9C.unk_58);
+            var_v1 = &D_80776A78[2];
+        } else {
+            func_80711BF0(arg1, &D_80776AA8.unk_58);
+            var_v1 = &D_80776A48[2];
+        }
+        player->unk_04 = 5;
+        temp_a3->unk_00.unk_00.unk_48.x = 0.0f;
+        temp_a3->unk_00.unk_00.unk_48.y = 0.0f;
+        temp_a3->unk_00.unk_00.unk_48.z = 0.0f;
+
+        temp_a3->unk_68[1] = var_v1->y;
+        temp_a3->unk_68[4] = var_v1->z;
+        temp_a0->unk_00.unk_18[7] = var_v1->x;
+
+        if (gNumPlayers == 2) {
+            var_v1 = &D_80776A78[player->cameraSetting];
+        } else {
+            var_v1 = &D_80776A48[player->cameraSetting];
+        }
+        temp_a3->unk_68[2] = var_v1->y;
+        temp_a3->unk_68[5] = var_v1->z;
+        temp_a0->unk_00.unk_18[8] = var_v1->x;
+
+        temp_t4 = &gRacers[player->id];
+        temp_a3->unk_00.unk_54.x = temp_t4->unk_180.x - (var_v1->y * temp_t4->unk_C0.x.x);
+        temp_a3->unk_00.unk_54.y = temp_t4->unk_180.y - (var_v1->y * temp_t4->unk_C0.x.y);
+        temp_a3->unk_00.unk_54.z = temp_t4->unk_180.z - (var_v1->y * temp_t4->unk_C0.x.z);
+
+        player->unk_20 = temp_t4->unk_180;
+        player->unk_2C = temp_t4->unk_C0;
+
+        player->unk_14 = arg1->unk_04.unk_00.unk_18[8];
+        player->unk_10 = 0;
+        if ((player->cameraSetting == 1) || (player->cameraSetting == 2)) {
+            player->unk_10 |= 1;
+        }
+        temp_a3->unk_68[6] = 0.1f;
+        temp_a3->unk_68[3] = 0.1f;
+        temp_a0->unk_00.unk_18[6] = 0.1f;
+        temp_a0->unk_00.unk_18[9] = 0.1f;
+        temp_a0->unk_00.unk_18[15] = 0.1f;
+    } else {
+        player->unk_1C++;
+    }
+}
+
+extern s16 D_807A16CC;
+extern s32 gPlayerControlPorts[];
+extern s32 gCurrentGhostType;
+extern s32 gFastestGhostTime;
+
+void func_80718530(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    f32 var_fa0;
+    f32 var_fv1;
+    s32 playerIndex;
+    bool var_v1;
+    unk_8008112C_arg_1* temp_a1;
+    s32 pad[4];
+    Racer* temp_t0;
+    unk_struct_9C* temp_a2 = &arg1->unk_04.unk_58;
+    Controller* controller;
+
+    playerIndex = player->id;
+    temp_t0 = &gRacers[playerIndex];
+    if (!gGamePaused) {
+        if (temp_t0->stateFlags & RACER_STATE_FLAGS_80000) {
+            player->unk_04 = 7;
+            func_807166B8(player, arg1, arg2);
+            return;
+        }
+        if (temp_t0->stateFlags & RACER_STATE_FLAGS_2000000) {
+            if ((gNumPlayers >= 2) && (D_807A16CC != 0)) {
+                player->unk_04 = 9;
+                func_807166B8(player, arg1, arg2);
+                return;
+            }
+            if (gGameMode == GAMEMODE_TIME_ATTACK) {
+                if ((gCurrentGhostType != GHOST_STAFF) && (gCurrentGhostType != GHOST_CELEBRITY) &&
+                    (gCurrentGhostType != GHOST_CHAMP)) {
+                    player->unk_04 = 8;
+                } else if (temp_t0->raceTime < gFastestGhostTime) {
+                    player->unk_04 = 8;
+                } else {
+                    player->unk_04 = 10;
+                }
+            } else {
+                player->unk_04 = 8;
+            }
+            func_807166B8(player, arg1, arg2);
+            return;
+        }
+    }
+
+    controller = &gControllers[gPlayerControlPorts[playerIndex]];
+    var_v1 = false;
+
+    if (!(temp_t0->stateFlags & RACER_STATE_RETIRED) && (controller->buttonPressed & BTN_CRIGHT)) {
+        var_v1 = true;
+        if (++player->cameraSetting == 4) {
+            player->cameraSetting = 0;
+        }
+    }
+    if (var_v1) {
+        func_80713064(player, &arg1->unk_04, temp_a2, gNumPlayers);
+    }
+    temp_a1 = &arg1->unk_04;
+    if ((D_8076D6C4 != 0) && (!gGamePaused)) {
+        if ((controller->buttonCurrent & BTN_CUP) && !(temp_t0->stateFlags & RACER_STATE_RETIRED)) {
+            if (++player->cameraLookBackRotate > sMaxCameraLookBackRotate) {
+                player->cameraLookBackRotate = sMaxCameraLookBackRotate;
+            }
+        } else {
+            if (--player->cameraLookBackRotate < 0) {
+                player->cameraLookBackRotate = 0;
+            }
+        }
+        temp_a2->unk_68[8] = (player->cameraLookBackRotate * 180.0f) / sMaxCameraLookBackRotate;
+    }
+    if (player->unk_10 & 1) {
+
+        var_fv1 = sqrtf(SQ(temp_t0->unk_5C.x) + SQ(temp_t0->unk_5C.z)) - D_8076D8A8;
+        if (var_fv1 < 0.0f) {
+            var_fa0 = player->unk_14;
+        } else {
+            var_fv1 /= (D_8076D8AC - D_8076D8A8);
+            if (var_fv1 > 1.0f) {
+                var_fv1 = 1.0f;
+            }
+
+            var_fa0 = player->unk_14 + ((120.0f - player->unk_14) * var_fv1);
+        }
+        if (player->unk_10 & 2) {
+            temp_a1->unk_00.unk_18[8] = var_fa0;
+        } else {
+            temp_a1->unk_00.unk_18[8] = var_fa0;
+            temp_a1->unk_00.unk_18[7] = var_fa0;
+        }
+    }
+    var_fv1 = temp_a1->unk_00.unk_18[8] - temp_a1->unk_00.unk_18[7];
+
+    if (ABS(var_fv1) < 0.1f) {
+        player->unk_10 &= ~2;
+    }
+}
+
+void func_80718908(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    s32 playerIndex = player->id;
+
+    if (gRacers[playerIndex].stateFlags & RACER_STATE_FLAGS_80000) {
+        player->unk_04 = 7;
+        func_807166B8(player, arg1, arg2);
+    }
+}
+
+extern s8 D_8007B9DC;
+
+void func_80718964(Player* player, unk_struct_F8* arg1) {
+    s32 i;
+    unk_struct_9C* temp_v0 = &arg1->unk_04.unk_58;
+
+    if (D_8007B9DC != 0) {
+        temp_v0->unk_00.unk_00.unk_48.y += 1.0f;
+        if (temp_v0->unk_00.unk_00.unk_48.y >= 360.0f) {
+            temp_v0->unk_00.unk_00.unk_48.y -= 360.0f;
+        }
+        if (player->unk_18 == 0) {
+            for (i = 0; i < gNumPlayers; i++) {
+                Controller* controller = &gControllers[gPlayerControlPorts[i]];
+
+                if (controller->buttonCurrent & BTN_CUP) {
+                    temp_v0->unk_00.unk_00.unk_3C.y += 0.1f;
+                }
+                if (controller->buttonCurrent & BTN_CDOWN) {
+                    temp_v0->unk_00.unk_00.unk_3C.y -= 0.1f;
+                }
+            }
+        } else {
+            player->unk_18 = 0;
+            temp_v0->unk_00.unk_00.unk_3C.y = 20.0f;
+        }
+
+        if (temp_v0->unk_00.unk_00.unk_3C.y < -50.0f) {
+            temp_v0->unk_00.unk_00.unk_3C.y = -50.0f;
+        } else if (temp_v0->unk_00.unk_00.unk_3C.y > 90.0f) {
+            temp_v0->unk_00.unk_00.unk_3C.y = 90.0f;
+        }
+    }
+}
+
+void func_80718AB0(Player* player, unk_struct_F8* arg1) {
+    arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_00 = gRacers[player->id].unk_180;
+}
+
+void func_80718AFC(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    unk_struct_9C* temp_v1 = &arg1->unk_04.unk_58;
+    Vec3f* temp_s1 = &D_807A15A0[player->id];
+    unk_800CD970* temp_a3 = &D_8076D788[player->unk_18];
+    unk_8008112C_arg_1* temp_t0 = &arg1->unk_04;
+    s16 temp_t1 = temp_a3->unk_00;
+    Racer* temp_t2 = &gRacers[player->id];
+    unk_800CD8B0* temp_v0_2;
+    s32 pad[2];
+
+    if (temp_t2->stateFlags & RACER_STATE_FLAGS_80000) {
+        player->unk_04 = 7;
+        func_807166B8(player, arg1, arg2);
+        return;
+    }
+    switch (temp_a3->unk_00) {
+        case 0:
+            temp_v1->unk_00.unk_00.unk_00.unk_00 = temp_t2->unk_180;
+            temp_v1->unk_00.unk_00.unk_00.unk_0C.x = temp_s1->x;
+            temp_v1->unk_00.unk_00.unk_00.unk_0C.y = temp_s1->y;
+            temp_v1->unk_00.unk_00.unk_00.unk_0C.z = temp_s1->z;
+            break;
+        case 1:
+            temp_v0_2 = (unk_800CD8B0*) temp_a3->unk_08;
+
+            *((Mtx3F*) &temp_v1->unk_00.unk_00.unk_00.unk_0C) = temp_t2->unk_C0;
+
+            temp_t0->unk_00.unk_18[3] = temp_v1->unk_00.unk_00.unk_00.unk_18;
+            temp_t0->unk_00.unk_18[4] = temp_v1->unk_00.unk_00.unk_00.unk_1C;
+            temp_t0->unk_00.unk_18[5] = temp_v1->unk_00.unk_00.unk_20;
+            temp_v1->unk_00.unk_00.unk_00.unk_00 = temp_t2->unk_180;
+
+            temp_v1->unk_00.unk_00.unk_3C.x =
+                temp_v0_2->unk_00.x +
+                ((((temp_v0_2->unk_0C.x - temp_v0_2->unk_00.x) * player->unk_1C) / temp_a3->unk_02) *
+                 temp_v0_2->unk_30);
+            temp_v1->unk_00.unk_00.unk_3C.y =
+                temp_v0_2->unk_00.y +
+                ((((temp_v0_2->unk_0C.y - temp_v0_2->unk_00.y) * player->unk_1C) / temp_a3->unk_02) *
+                 temp_v0_2->unk_30);
+            temp_v1->unk_00.unk_00.unk_3C.z =
+                temp_v0_2->unk_00.z +
+                ((((temp_v0_2->unk_0C.z - temp_v0_2->unk_00.z) * player->unk_1C) / temp_a3->unk_02) *
+                 temp_v0_2->unk_30);
+
+            temp_v1->unk_00.unk_54.x =
+                temp_v0_2->unk_18.x +
+                ((((temp_v0_2->unk_24.x - temp_v0_2->unk_18.x) * player->unk_1C) / temp_a3->unk_02) *
+                 temp_v0_2->unk_34);
+            temp_v1->unk_00.unk_54.y =
+                temp_v0_2->unk_18.y +
+                ((((temp_v0_2->unk_24.y - temp_v0_2->unk_18.y) * player->unk_1C) / temp_a3->unk_02) *
+                 temp_v0_2->unk_34);
+            temp_v1->unk_00.unk_54.z =
+                temp_v0_2->unk_18.z +
+                ((((temp_v0_2->unk_24.z - temp_v0_2->unk_18.z) * player->unk_1C) / temp_a3->unk_02) *
+                 temp_v0_2->unk_34);
+        default:
+            break;
+    }
+
+    if (player->unk_1C >= temp_a3->unk_02) {
+        player->unk_1C = 0;
+        if (++player->unk_18 >= 5) {
+            player->unk_04 = 9;
+            func_807166B8(player, arg1, arg2);
+            return;
+        }
+        temp_a3 = &D_8076D788[player->unk_18];
+        temp_t0->unk_00.unk_18[8] = temp_a3->unk_04;
+
+        switch (temp_a3->unk_00) {
+            case 0:
+                if (temp_t1 != temp_a3->unk_00) {
+                    func_80711B20(arg1, &D_807763D0.unk_58);
+                }
+                temp_t0->unk_00.unk_18[3] = 0.0f;
+                temp_t0->unk_00.unk_18[4] = 1.0f;
+                temp_t0->unk_00.unk_18[5] = 0.0f;
+                func_80718F58(temp_s1, temp_t2->unk_0C.courseSegment, temp_t2->unk_0C.unk_04, temp_a3);
+                temp_v1->unk_00.unk_00.unk_00.unk_00 = temp_t2->unk_180;
+                temp_v1->unk_00.unk_00.unk_00.unk_0C.x = temp_s1->x;
+                temp_v1->unk_00.unk_00.unk_00.unk_0C.y = temp_s1->y;
+                temp_v1->unk_00.unk_00.unk_00.unk_0C.z = temp_s1->z;
+                break;
+            case 1:
+                if (temp_t1 != temp_a3->unk_00) {
+                    func_80711D58(arg1, &D_807765E8.unk_58);
+                }
+                temp_v0_2 = (unk_800CD8B0*) temp_a3->unk_08;
+                temp_v1->unk_00.unk_00.unk_3C = temp_v0_2->unk_00;
+                temp_v1->unk_00.unk_54 = temp_v0_2->unk_18;
+                break;
+            default:
+                break;
+        }
+    } else {
+        player->unk_1C++;
+    }
+}
+
+void func_80718F58(Vec3f* arg0, CourseSegment* arg1, f32 arg2, unk_800CD970* arg3) {
+    f32 abs;
+    f32 sp60;
+    f32 temp_fa1;
+    f32 temp_ft4;
+    f32 var_fa0;
+    f32 var_fv0;
+    Mtx3F sp2C;
+    unk_800CD8B0* sp28 = (unk_800CD8B0*) arg3->unk_08;
+
+    sp60 = func_80712E68(&arg1, arg2, sp28->unk_00.x);
+
+    func_i2_800B26B8(arg1, sp60, arg0);
+    func_80712FE4(&sp2C, arg1, sp60);
+
+    temp_ft4 = arg1->radiusLeft * (1.0f - sp60) + arg1->next->radiusLeft * sp60;
+    temp_fa1 = arg1->radiusRight * (1.0f - sp60) + arg1->next->radiusRight * sp60;
+
+    switch (arg1->trackSegmentInfo & TRACK_SHAPE_MASK) {
+        case TRACK_SHAPE_CYLINDER:
+            var_fv0 = sp28->unk_00.y * temp_fa1;
+            var_fa0 = sp28->unk_00.z + temp_fa1;
+            break;
+        case TRACK_SHAPE_HALF_PIPE:
+            var_fv0 = sp28->unk_00.y * temp_ft4;
+            var_fa0 = sp28->unk_00.z;
+            break;
+        default:
+            if (sp28->unk_00.y >= 0.0f) {
+                var_fv0 = sp28->unk_00.y * temp_ft4;
+            } else {
+                var_fv0 = sp28->unk_00.y * temp_fa1;
+            }
+            var_fa0 = sp28->unk_00.z;
+            break;
+    }
+
+    abs = ABS(var_fv0);
+    if (D_8076D8B0 < abs) {
+        abs = D_8076D8B0;
+        if (var_fv0 < 0) {
+            var_fv0 = 0.0f - abs;
+        } else {
+            var_fv0 = abs;
+        }
+    }
+
+    arg0->x += (sp2C.y.x * var_fa0) + (sp2C.z.x * var_fv0);
+    arg0->y += (sp2C.y.y * var_fa0) + (sp2C.z.y * var_fv0);
+    arg0->z += (sp2C.y.z * var_fa0) + (sp2C.z.z * var_fv0);
+}
+
+void func_80719140(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+
+    if (player->unk_1C <= 60) {
+        arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_00 = gRacers[player->id].unk_0C.unk_34;
+        player->unk_1C++;
+    }
+}
+
+void func_807191B0(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    s32 pad;
+    f32 temp;
+    unk_struct_9C* temp_v1 = &arg1->unk_04.unk_58;
+    Racer* temp_a3 = &gRacers[player->id];
+    unk_8008112C_arg_1* temp_a0 = &arg1->unk_04;
+
+    if (temp_a3->stateFlags & RACER_STATE_FLAGS_80000) {
+        player->unk_04 = 7;
+        func_807166B8(player, arg1, arg2);
+        return;
+    }
+    temp_v1->unk_00.unk_00.unk_00.unk_18 += temp_a3->unk_B4.x * 0.3f;
+    temp_v1->unk_00.unk_00.unk_00.unk_1C += temp_a3->unk_B4.y * 0.3f;
+    temp_v1->unk_00.unk_00.unk_20 += temp_a3->unk_B4.z * 0.3f;
+
+    func_806F6F64((Mtx3F*) &temp_v1->unk_00.unk_00.unk_00.unk_0C);
+
+    temp_a0->unk_00.unk_18[3] = temp_v1->unk_00.unk_00.unk_00.unk_18;
+    temp_a0->unk_00.unk_18[4] = temp_v1->unk_00.unk_00.unk_00.unk_1C;
+    temp_a0->unk_00.unk_18[5] = temp_v1->unk_00.unk_00.unk_20;
+
+    temp_v1->unk_00.unk_00.unk_00.unk_00 = temp_a3->unk_180;
+
+    switch (player->unk_18) {
+        case 0:
+            if (++player->unk_1C >= 180) {
+                player->unk_18 = 1;
+                player->unk_1C = 0;
+                temp_v1->unk_00.unk_00.unk_30.z = 0.005f;
+            }
+            break;
+        case 1:
+            if (++player->unk_1C >= 300) {
+                player->unk_1C = 0;
+                temp_v1->unk_00.unk_00.unk_30.y = (Math_Rand1() % 451) + 50.0f;
+            }
+            temp_v1->unk_00.unk_00.unk_48.y += 0.4f;
+
+            if (temp_v1->unk_00.unk_00.unk_48.y >= 360.0f) {
+                temp_v1->unk_00.unk_00.unk_48.y -= 360.0f;
+            }
+            break;
+        default:
+            break;
+    }
+
+    if ((D_8076D6C0 == player->id) && (gNumPlayers == 2)) {
+
+        if (player->unk_E4 < player->unk_E6) {
+            temp = (f32) (player->unk_E4 + 1) / player->unk_E6;
+            arg1->unk_04.unk_00.unk_18[13] = -30.0f - (-30.0f * temp);
+        } else {
+            arg1->unk_04.unk_00.unk_18[13] = 0.0f;
+        }
+    }
+}
+
+void func_80719420(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    Racer* racer = &gRacers[player->id];
+
+    if (racer->stateFlags & RACER_STATE_FLAGS_80000) {
+        player->unk_04 = 7;
+        func_807166B8(player, arg1, arg2);
+    }
+}
+
+extern unk_struct_C D_800993D0[];
+extern unk_struct_C D_800996E0[];
+extern unk_struct_C D_80099A60[];
+extern unk_struct_C D_80099F70[];
+extern unk_struct_C D_8009A090[];
+extern unk_struct_C D_8009A210[];
+extern u16 D_8009AD16;
+
+void func_80719480(Player* player, unk_struct_F8* arg1, unk_800E5D70* arg2) {
+    s32 var_s3 = true;
+    Racer* temp_a3;
+    unk_struct_9C* temp_v0;
+    unk_struct_C* var_a1;
+
+    while (var_s3) {
+
+        var_s3 = false;
+        switch (player->unk_18) {
+            case 0:
+                if (func_80719868(1)) {
+                    if (D_8009AD16 & 0x40) {
+                        var_s3 = true;
+                        player->unk_18 = 2;
+                        func_80711D58(arg1, &D_807765E8.unk_58);
+                        arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.z = 0.0f;
+                        arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.y = 0.0f;
+                        arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.x = 0.0f;
+                        arg1->unk_04.unk_58.unk_00.unk_54.x = 0.0f;
+                        arg1->unk_04.unk_58.unk_00.unk_54.y = 37.0f;
+                        arg1->unk_04.unk_58.unk_00.unk_54.z = -132.0f;
+                    } else {
+                        player->unk_18 = 1;
+                        player->unk_1C = 0;
+                        if (D_807A1598 == 0) {
+                            var_a1 = D_800993D0;
+                        } else if (D_807A1598 == 1) {
+                            var_a1 = D_80099A60;
+                        } else {
+                            var_a1 = D_800996E0;
+                        }
+                        func_80714000(arg2, var_a1);
+                        temp_a3 = &gRacers[D_807A1598];
+                        func_80713FE4(&D_807A1480[player->id], &temp_a3->unk_180, &temp_a3->unk_C0, temp_a3);
+                    }
+                }
+                break;
+            case 1:
+                if (func_8071403C(arg2)) {
+                    player->unk_18 = 2;
+                    arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.x = 0.0f;
+                    arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.y = 0.0f;
+                    arg1->unk_04.unk_58.unk_00.unk_00.unk_3C.z = 0.0f;
+                    arg1->unk_04.unk_58.unk_00.unk_54.x = 0.0f;
+                    arg1->unk_04.unk_58.unk_00.unk_54.y = 37.0f;
+                    var_s3 = true;
+                    temp_v0 = &arg1->unk_04.unk_58;
+                    if (D_8009AD16 & 2) {
+                        temp_v0->unk_00.unk_54.z = 132.0f;
+                    } else {
+                        temp_v0->unk_00.unk_54.z = -132.0f;
+                    }
+                }
+                break;
+            case 2:
+                temp_a3 = &gRacers[D_807A1598];
+                *((Mtx3F*) &arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_0C) = temp_a3->unk_C0;
+                arg1->unk_04.unk_58.unk_00.unk_00.unk_00.unk_00 = temp_a3->unk_180;
+                if (func_80719868(4)) {
+                    player->unk_18 = 3;
+                    player->unk_1C = 0;
+                    temp_a3 = &gRacers[2];
+                    func_80713FE4(&D_807A1480[player->id], &temp_a3->unk_180, &temp_a3->unk_C0, temp_a3);
+                    func_80714000(arg2, D_8009A210);
+                }
+                break;
+            case 3:
+                if (func_8071403C(arg2) && func_80719868(3)) {
+                    player->unk_18 = 4;
+                    player->unk_1C = 0;
+                    temp_a3 = &gRacers[1];
+                    func_80713FE4(&D_807A1480[player->id], &temp_a3->unk_180, &temp_a3->unk_C0, temp_a3);
+                    func_80714000(arg2, D_8009A090);
+                }
+                break;
+            case 4:
+                if (func_8071403C(arg2) && func_80719868(2)) {
+                    player->unk_18 = 5;
+                    player->unk_1C = 0;
+                    temp_a3 = &gRacers[0];
+                    func_80713FE4(&D_807A1480[player->id], &temp_a3->unk_180, &temp_a3->unk_C0, temp_a3);
+                    func_80714000(arg2, D_80099F70);
+                }
+                break;
+            case 5:
+                func_8071403C(arg2);
+                break;
+        }
+    }
+    // FAKE, likely some recast somewhere
+    if (!arg1) {}
+}
+
+void func_8071985C(s32 arg0) {
+    D_807A1594 = arg0;
+}
+
+bool func_80719868(s32 arg0) {
+    bool var_v1 = false;
+
+    if (arg0 == D_807A1594) {
+        var_v1 = true;
+        D_807A1594 = 0;
+    }
+    return var_v1;
+}
+
+void func_80719890(Gfx* gfx) {
+
+    gSPPerspNormalize(gfx++, gPlayers[0].unk_118);
+    gSPMatrix(gfx++, &D_1000000.unk_1A208[gPlayers[0].id], G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    func_80713E38(gfx, 0, gPlayers->id);
+}

--- a/src/overlays/ovl_i2/save.c
+++ b/src/overlays/ovl_i2/save.c
@@ -990,7 +990,7 @@ void Save_SaveSettings(SaveSettings* saveSettings) {
     if (gSettingSoundMode != 0) {
         settingLowerFlags |= 4;
     }
-    if (gSettingEverythingUnlocked != 0) {
+    if (gSettingEverythingUnlocked) {
         settingLowerFlags |= 8;
     }
 
@@ -1265,9 +1265,9 @@ void Save_LoadSaveSettings(ProfileSave* profileSaves, bool arg1) {
         gSettingSoundMode = 0;
     }
     if (saveSettings->settings & 8) {
-        gSettingEverythingUnlocked = 1;
+        gSettingEverythingUnlocked = true;
     } else {
-        gSettingEverythingUnlocked = 0;
+        gSettingEverythingUnlocked = false;
     }
 
     for (i = JACK_CUP; i <= JOKER_CUP; i++) {

--- a/src/overlays/ovl_i4/ovl_i4.h
+++ b/src/overlays/ovl_i4/ovl_i4.h
@@ -1,0 +1,25 @@
+#ifndef OVL_I4_H
+#define OVL_I4_H
+
+#include "libultra/ultra64.h"
+
+typedef enum MachineSelectState {
+    MACHINE_SELECT_ACTIVE,
+    MACHINE_SELECT_EXIT,
+    MACHINE_SELECT_AWAIT_OK,
+    MACHINE_SELECT_CONTINUE,
+} MachineSelectState;
+
+typedef enum MachineSettingsState {
+    MACHINE_SETTINGS_ACTIVE,
+    MACHINE_SETTINGS_EXIT,
+    MACHINE_SETTINGS_AWAIT_OK,
+    MACHINE_SETTINGS_CONTINUE,
+} MachineSettingsState;
+
+typedef enum PlayerSelectionLockState {
+    SELECTION_FREE,
+    SELECTION_LOCKED,
+} PlayerSelectionLockState;
+
+#endif // OVL_I4_H

--- a/yamls/jp/main.yaml
+++ b/yamls/jp/main.yaml
@@ -80,7 +80,9 @@
       - [0x157F0, c]
       - [0x15AB0, c]
       - [0x17490, c]
+      - [0x1B6E0, c]
       - [0x1C8B0, c]
+      - [0x1C8F0, c]
       - [0x1C970, c, leo_fault]
       - [0x1D580, c, sys_fault]
       - [0x1E970, c]
@@ -293,9 +295,13 @@
       - [0x7A140, .data, 3A10]
       - [0x7A150, .data, 6F50]
       - [0x7A340, data]
+      - [0x7A450, .data, 17490]
+      - [0x7A620, .data, 1C8B0]
+      - [0x7A800, .data, 1C8F0]
       - [0x7A810, .data, leo_fault]
       - [0x7ACE0, .data, sys_fault]
-      - [0x7AEC0, data]
+      - [0x7AEC0, .data, 1F320]
+      - [0x7B0C0, data]
       - [0x7DB20, .data, audio/filter_data]
       - [0x7DD10, .data, audio/note_data]
       - [0x7F130, .data, audio/synthesis]
@@ -454,9 +460,13 @@
       - { type: .bss, vram: 0x8079A8A0, name: 3A10 }
       - { type: .bss, vram: 0x8079E920, name: 6F50 }
       - { type: bss, vram: 0x8079F950, name: 8079F950 }
+      - { type: .bss, vram: 0x8079FAA0, name: 17490 }
+      - { type: .bss, vram: 0x8079FC10, name: 1C8B0 }
       - { type: .bss, vram: 0x8079FC80, name: leo_fault }
       - { type: .bss, vram: 0x8079FE80, name: sys_fault }
-      - { type: bss, vram: 0x807A0870, name: 807A0870 }
+      - { type: .bss, vram: 0x807A0870, name: 1E970 }
+      - { type: .bss, vram: 0x807A0930, name: 1F320 }
+      - { type: bss, vram: 0x807A15D0, name: 807A15D0 }
       - { type: .bss, vram: 0x807C1C00, name: libultra/io/sptask }
       - { type: .bss, vram: 0x807C1C40, name: libultra/io/motor }
       - { type: .bss, vram: 0x807C1D40, name: libultra/io/siacs }


### PR DESCRIPTION
Matches up to and including 1F320.c

1F320 is the first half of 1B0E0 on base decomp, so that will mean that file needs a split, which makes sense for the code that's here.

1F320 is honestly the messiest matching part of the decomp, as there are a lot of conflicting struct copies that are used with stuff that is basically just float buffers. For now I am not going to clean this up as I cannot think of a way that leads to a clean codebase