### PR TITLE
Match Ovl xk4

### DIFF
--- a/assets/yaml/jp/overlays/ovl_xk4/a1E0B00.yaml
+++ b/assets/yaml/jp/overlays/ovl_xk4/a1E0B00.yaml
@@ -1,0 +1,1701 @@
+:config:
+  virtual:
+    [0x800D6D90, 0x1E0B00]
+  header:
+    code:
+      - '#include "assets/overlays/ovl_xk4/a1E0B00.h"'
+    header:
+      - '#include "libultra/ultra64.h"'
+
+D_xk4_800DA250:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 8
+  height: 8
+  offset: 0x1E3FC0
+  symbol: D_xk4_800DA250
+
+D_xk4_800DA2D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E4040
+  symbol: D_xk4_800DA2D0
+
+D_xk4_800DAAD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E4840
+  symbol: D_xk4_800DAAD0
+
+D_xk4_800DB2D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E5040
+  symbol: D_xk4_800DB2D0
+
+D_xk4_800DBAD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 64
+  height: 32
+  offset: 0x1E5840
+  symbol: D_xk4_800DBAD0
+
+D_xk4_800DCAD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 64
+  offset: 0x1E6840
+  symbol: D_xk4_800DCAD0
+
+D_xk4_800DDAD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E7840
+  symbol: D_xk4_800DDAD0
+
+D_xk4_800DE2D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E8040
+  symbol: D_xk4_800DE2D0
+
+D_xk4_800DEAD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E8840
+  symbol: D_xk4_800DEAD0
+
+D_xk4_800DF2D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E9040
+  symbol: D_xk4_800DF2D0
+
+D_xk4_800DFAD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1E9840
+  symbol: D_xk4_800DFAD0
+
+D_xk4_800E02D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 16
+  height: 16
+  offset: 0x1EA040
+  symbol: D_xk4_800E02D0
+
+D_xk4_800E04D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 64
+  height: 32
+  offset: 0x1EA240
+  symbol: D_xk4_800E04D0
+
+D_xk4_800E14D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 64
+  height: 32
+  offset: 0x1EB240
+  symbol: D_xk4_800E14D0
+
+D_xk4_800E24D0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 32
+  height: 32
+  offset: 0x1EC240
+  symbol: D_xk4_800E24D0
+
+D_xk4_800E2CD0:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 8
+  height: 8
+  offset: 0x1ECA40
+  symbol: D_xk4_800E2CD0
+
+D_xk4_800E2D50:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 16
+  height: 16
+  offset: 0x1ECAC0
+  symbol: D_xk4_800E2D50
+
+D_xk4_800E2F50:
+  type: VTX
+  offset: 0x1ECCC0
+  count: 21
+  symbol: D_xk4_800E2F50
+
+D_xk4_800E30A0:
+  type: VTX
+  offset: 0x1ECE10
+  count: 4
+  symbol: D_xk4_800E30A0
+
+D_xk4_800E30E0:
+  type: VTX
+  offset: 0x1ECE50
+  count: 14
+  symbol: D_xk4_800E30E0
+
+D_xk4_800E31C0:
+  type: VTX
+  offset: 0x1ECF30
+  count: 27
+  symbol: D_xk4_800E31C0
+
+D_xk4_800E3370:
+  type: VTX
+  offset: 0x1ED0E0
+  count: 3
+  symbol: D_xk4_800E3370
+
+D_xk4_800E33A0:
+  type: VTX
+  offset: 0x1ED110
+  count: 5
+  symbol: D_xk4_800E33A0
+
+D_xk4_800E33F0:
+  type: VTX
+  offset: 0x1ED160
+  count: 24
+  symbol: D_xk4_800E33F0
+
+D_xk4_800E3570:
+  type: VTX
+  offset: 0x1ED2E0
+  count: 14
+  symbol: D_xk4_800E3570
+
+D_xk4_800E3650:
+  type: VTX
+  offset: 0x1ED3C0
+  count: 18
+  symbol: D_xk4_800E3650
+
+D_xk4_800E3770:
+  type: VTX
+  offset: 0x1ED4E0
+  count: 18
+  symbol: D_xk4_800E3770
+
+D_xk4_800E3890:
+  type: VTX
+  offset: 0x1ED600
+  count: 89
+  symbol: D_xk4_800E3890
+
+D_xk4_800E3E20:
+  type: VTX
+  offset: 0x1EDB90
+  count: 60
+  symbol: D_xk4_800E3E20
+
+D_xk4_800E41E0:
+  type: VTX
+  offset: 0x1EDF50
+  count: 22
+  symbol: D_xk4_800E41E0
+
+D_xk4_800E4340:
+  type: VTX
+  offset: 0x1EE0B0
+  count: 6
+  symbol: D_xk4_800E4340
+
+D_xk4_800E43A0:
+  type: VTX
+  offset: 0x1EE110
+  count: 14
+  symbol: D_xk4_800E43A0
+
+D_xk4_800E4480:
+  type: VTX
+  offset: 0x1EE1F0
+  count: 17
+  symbol: D_xk4_800E4480
+
+D_xk4_800E4590:
+  type: VTX
+  offset: 0x1EE300
+  count: 4
+  symbol: D_xk4_800E4590
+
+D_xk4_800E45D0:
+  type: VTX
+  offset: 0x1EE340
+  count: 32
+  symbol: D_xk4_800E45D0
+
+D_xk4_800E47D0:
+  type: VTX
+  offset: 0x1EE540
+  count: 9
+  symbol: D_xk4_800E47D0
+
+D_xk4_800E4860:
+  type: VTX
+  offset: 0x1EE5D0
+  count: 127
+  symbol: D_xk4_800E4860
+
+D_xk4_800E5050:
+  type: VTX
+  offset: 0x1EEDC0
+  count: 11
+  symbol: D_xk4_800E5050
+
+D_xk4_800E5100:
+  type: VTX
+  offset: 0x1EEE70
+  count: 2
+  symbol: D_xk4_800E5100
+
+D_xk4_800E5120:
+  type: VTX
+  offset: 0x1EEE90
+  count: 19
+  symbol: D_xk4_800E5120
+
+D_xk4_800E5250:
+  type: VTX
+  offset: 0x1EEFC0
+  count: 6
+  symbol: D_xk4_800E5250
+
+D_xk4_800E52B0:
+  type: VTX
+  offset: 0x1EF020
+  count: 6
+  symbol: D_xk4_800E52B0
+
+D_xk4_800E5310:
+  type: VTX
+  offset: 0x1EF080
+  count: 32
+  symbol: D_xk4_800E5310
+
+D_xk4_800E5510:
+  type: VTX
+  offset: 0x1EF280
+  count: 42
+  symbol: D_xk4_800E5510
+
+D_xk4_800E57B0:
+  type: VTX
+  offset: 0x1EF520
+  count: 21
+  symbol: D_xk4_800E57B0
+
+D_xk4_800E5900:
+  type: VTX
+  offset: 0x1EF670
+  count: 21
+  symbol: D_xk4_800E5900
+
+D_xk4_800E5A50:
+  type: VTX
+  offset: 0x1EF7C0
+  count: 8
+  symbol: D_xk4_800E5A50
+
+D_xk4_800E5AD0:
+  type: VTX
+  offset: 0x1EF840
+  count: 3
+  symbol: D_xk4_800E5AD0
+
+D_xk4_800E5B00:
+  type: VTX
+  offset: 0x1EF870
+  count: 2
+  symbol: D_xk4_800E5B00
+
+D_xk4_800E5B20:
+  type: VTX
+  offset: 0x1EF890
+  count: 21
+  symbol: D_xk4_800E5B20
+
+D_xk4_800E5C70:
+  type: VTX
+  offset: 0x1EF9E0
+  count: 32
+  symbol: D_xk4_800E5C70
+
+D_xk4_800E5E70:
+  type: VTX
+  offset: 0x1EFBE0
+  count: 3
+  symbol: D_xk4_800E5E70
+
+D_xk4_800E5EA0:
+  type: VTX
+  offset: 0x1EFC10
+  count: 18
+  symbol: D_xk4_800E5EA0
+
+D_xk4_800E5FC0:
+  type: VTX
+  offset: 0x1EFD30
+  count: 4
+  symbol: D_xk4_800E5FC0
+
+D_xk4_800E6000:
+  type: VTX
+  offset: 0x1EFD70
+  count: 3
+  symbol: D_xk4_800E6000
+
+D_xk4_800E6030:
+  type: VTX
+  offset: 0x1EFDA0
+  count: 2
+  symbol: D_xk4_800E6030
+
+D_xk4_800E6050:
+  type: VTX
+  offset: 0x1EFDC0
+  count: 8
+  symbol: D_xk4_800E6050
+
+D_xk4_800E60D0:
+  type: VTX
+  offset: 0x1EFE40
+  count: 6
+  symbol: D_xk4_800E60D0
+
+D_xk4_800E6130:
+  type: VTX
+  offset: 0x1EFEA0
+  count: 7
+  symbol: D_xk4_800E6130
+
+D_xk4_800E61A0:
+  type: VTX
+  offset: 0x1EFF10
+  count: 8
+  symbol: D_xk4_800E61A0
+
+D_xk4_800E6220:
+  type: VTX
+  offset: 0x1EFF90
+  count: 8
+  symbol: D_xk4_800E6220
+
+D_xk4_800E62A0:
+  type: VTX
+  offset: 0x1F0010
+  count: 13
+  symbol: D_xk4_800E62A0
+
+D_xk4_800E6370:
+  type: VTX
+  offset: 0x1F00E0
+  count: 3
+  symbol: D_xk4_800E6370
+
+D_xk4_800E63A0:
+  type: VTX
+  offset: 0x1F0110
+  count: 4
+  symbol: D_xk4_800E63A0
+
+D_xk4_800E63E0:
+  type: VTX
+  offset: 0x1F0150
+  count: 4
+  symbol: D_xk4_800E63E0
+
+D_xk4_800E6420:
+  type: VTX
+  offset: 0x1F0190
+  count: 12
+  symbol: D_xk4_800E6420
+
+D_xk4_800E64E0:
+  type: VTX
+  offset: 0x1F0250
+  count: 9
+  symbol: D_xk4_800E64E0
+
+D_xk4_800E6570:
+  type: VTX
+  offset: 0x1F02E0
+  count: 3
+  symbol: D_xk4_800E6570
+
+D_xk4_800E65A0:
+  type: VTX
+  offset: 0x1F0310
+  count: 14
+  symbol: D_xk4_800E65A0
+
+D_xk4_800E6680:
+  type: VTX
+  offset: 0x1F03F0
+  count: 14
+  symbol: D_xk4_800E6680
+
+D_xk4_800E6760:
+  type: VTX
+  offset: 0x1F04D0
+  count: 13
+  symbol: D_xk4_800E6760
+
+D_xk4_800E6830:
+  type: VTX
+  offset: 0x1F05A0
+  count: 15
+  symbol: D_xk4_800E6830
+
+D_xk4_800E6920:
+  type: VTX
+  offset: 0x1F0690
+  count: 6
+  symbol: D_xk4_800E6920
+
+D_xk4_800E6980:
+  type: VTX
+  offset: 0x1F06F0
+  count: 3
+  symbol: D_xk4_800E6980
+
+D_xk4_800E69B0:
+  type: VTX
+  offset: 0x1F0720
+  count: 2
+  symbol: D_xk4_800E69B0
+
+D_xk4_800E69D0:
+  type: VTX
+  offset: 0x1F0740
+  count: 21
+  symbol: D_xk4_800E69D0
+
+D_xk4_800E6B20:
+  type: VTX
+  offset: 0x1F0890
+  count: 32
+  symbol: D_xk4_800E6B20
+
+D_xk4_800E6D20:
+  type: VTX
+  offset: 0x1F0A90
+  count: 3
+  symbol: D_xk4_800E6D20
+
+D_xk4_800E6D50:
+  type: VTX
+  offset: 0x1F0AC0
+  count: 18
+  symbol: D_xk4_800E6D50
+
+D_xk4_800E6E70:
+  type: VTX
+  offset: 0x1F0BE0
+  count: 4
+  symbol: D_xk4_800E6E70
+
+D_xk4_800E6EB0:
+  type: VTX
+  offset: 0x1F0C20
+  count: 3
+  symbol: D_xk4_800E6EB0
+
+D_xk4_800E6EE0:
+  type: VTX
+  offset: 0x1F0C50
+  count: 2
+  symbol: D_xk4_800E6EE0
+
+D_xk4_800E6F00:
+  type: VTX
+  offset: 0x1F0C70
+  count: 8
+  symbol: D_xk4_800E6F00
+
+D_xk4_800E6F80:
+  type: VTX
+  offset: 0x1F0CF0
+  count: 6
+  symbol: D_xk4_800E6F80
+
+D_xk4_800E6FE0:
+  type: VTX
+  offset: 0x1F0D50
+  count: 7
+  symbol: D_xk4_800E6FE0
+
+D_xk4_800E7050:
+  type: VTX
+  offset: 0x1F0DC0
+  count: 8
+  symbol: D_xk4_800E7050
+
+D_xk4_800E70D0:
+  type: VTX
+  offset: 0x1F0E40
+  count: 8
+  symbol: D_xk4_800E70D0
+
+D_xk4_800E7150:
+  type: VTX
+  offset: 0x1F0EC0
+  count: 13
+  symbol: D_xk4_800E7150
+
+D_xk4_800E7220:
+  type: VTX
+  offset: 0x1F0F90
+  count: 3
+  symbol: D_xk4_800E7220
+
+D_xk4_800E7250:
+  type: VTX
+  offset: 0x1F0FC0
+  count: 4
+  symbol: D_xk4_800E7250
+
+D_xk4_800E7290:
+  type: VTX
+  offset: 0x1F1000
+  count: 4
+  symbol: D_xk4_800E7290
+
+D_xk4_800E72D0:
+  type: VTX
+  offset: 0x1F1040
+  count: 12
+  symbol: D_xk4_800E72D0
+
+D_xk4_800E7390:
+  type: VTX
+  offset: 0x1F1100
+  count: 9
+  symbol: D_xk4_800E7390
+
+D_xk4_800E7420:
+  type: VTX
+  offset: 0x1F1190
+  count: 3
+  symbol: D_xk4_800E7420
+
+D_xk4_800E7450:
+  type: VTX
+  offset: 0x1F11C0
+  count: 14
+  symbol: D_xk4_800E7450
+
+D_xk4_800E7530:
+  type: VTX
+  offset: 0x1F12A0
+  count: 14
+  symbol: D_xk4_800E7530
+
+D_xk4_800E7610:
+  type: VTX
+  offset: 0x1F1380
+  count: 13
+  symbol: D_xk4_800E7610
+
+D_xk4_800E76E0:
+  type: VTX
+  offset: 0x1F1450
+  count: 15
+  symbol: D_xk4_800E76E0
+
+D_xk4_800E77D0:
+  type: VTX
+  offset: 0x1F1540
+  count: 6
+  symbol: D_xk4_800E77D0
+
+D_xk4_800E7830:
+  type: VTX
+  offset: 0x1F15A0
+  count: 4
+  symbol: D_xk4_800E7830
+
+D_xk4_800E7870:
+  type: VTX
+  offset: 0x1F15E0
+  count: 20
+  symbol: D_xk4_800E7870
+
+D_xk4_800E79B0:
+  type: VTX
+  offset: 0x1F1720
+  count: 19
+  symbol: D_xk4_800E79B0
+
+D_xk4_800E7AE0:
+  type: VTX
+  offset: 0x1F1850
+  count: 6
+  symbol: D_xk4_800E7AE0
+
+D_xk4_800E7B40:
+  type: VTX
+  offset: 0x1F18B0
+  count: 4
+  symbol: D_xk4_800E7B40
+
+D_xk4_800E7B80:
+  type: VTX
+  offset: 0x1F18F0
+  count: 4
+  symbol: D_xk4_800E7B80
+
+D_xk4_800E7BC0:
+  type: VTX
+  offset: 0x1F1930
+  count: 3
+  symbol: D_xk4_800E7BC0
+
+D_xk4_800E7BF0:
+  type: VTX
+  offset: 0x1F1960
+  count: 10
+  symbol: D_xk4_800E7BF0
+
+D_xk4_800E7C90:
+  type: VTX
+  offset: 0x1F1A00
+  count: 7
+  symbol: D_xk4_800E7C90
+
+D_xk4_800E7D00:
+  type: VTX
+  offset: 0x1F1A70
+  count: 4
+  symbol: D_xk4_800E7D00
+
+D_xk4_800E7D40:
+  type: VTX
+  offset: 0x1F1AB0
+  count: 12
+  symbol: D_xk4_800E7D40
+
+D_xk4_800E7E00:
+  type: VTX
+  offset: 0x1F1B70
+  count: 8
+  symbol: D_xk4_800E7E00
+
+D_xk4_800E7E80:
+  type: VTX
+  offset: 0x1F1BF0
+  count: 12
+  symbol: D_xk4_800E7E80
+
+D_xk4_800E7F40:
+  type: VTX
+  offset: 0x1F1CB0
+  count: 3
+  symbol: D_xk4_800E7F40
+
+D_xk4_800E7F70:
+  type: VTX
+  offset: 0x1F1CE0
+  count: 7
+  symbol: D_xk4_800E7F70
+
+D_xk4_800E7FE0:
+  type: VTX
+  offset: 0x1F1D50
+  count: 8
+  symbol: D_xk4_800E7FE0
+
+D_xk4_800E8060:
+  type: VTX
+  offset: 0x1F1DD0
+  count: 9
+  symbol: D_xk4_800E8060
+
+D_xk4_800E80F0:
+  type: VTX
+  offset: 0x1F1E60
+  count: 5
+  symbol: D_xk4_800E80F0
+
+D_xk4_800E8140:
+  type: VTX
+  offset: 0x1F1EB0
+  count: 6
+  symbol: D_xk4_800E8140
+
+D_xk4_800E81A0:
+  type: VTX
+  offset: 0x1F1F10
+  count: 5
+  symbol: D_xk4_800E81A0
+
+D_xk4_800E81F0:
+  type: VTX
+  offset: 0x1F1F60
+  count: 4
+  symbol: D_xk4_800E81F0
+
+D_xk4_800E8230:
+  type: VTX
+  offset: 0x1F1FA0
+  count: 7
+  symbol: D_xk4_800E8230
+
+D_xk4_800E82A0:
+  type: VTX
+  offset: 0x1F2010
+  count: 9
+  symbol: D_xk4_800E82A0
+
+D_xk4_800E8330:
+  type: VTX
+  offset: 0x1F20A0
+  count: 4
+  symbol: D_xk4_800E8330
+
+D_xk4_800E8370:
+  type: VTX
+  offset: 0x1F20E0
+  count: 4
+  symbol: D_xk4_800E8370
+
+D_xk4_800E83B0:
+  type: VTX
+  offset: 0x1F2120
+  count: 20
+  symbol: D_xk4_800E83B0
+
+D_xk4_800E84F0:
+  type: VTX
+  offset: 0x1F2260
+  count: 19
+  symbol: D_xk4_800E84F0
+
+D_xk4_800E8620:
+  type: VTX
+  offset: 0x1F2390
+  count: 6
+  symbol: D_xk4_800E8620
+
+D_xk4_800E8680:
+  type: VTX
+  offset: 0x1F23F0
+  count: 4
+  symbol: D_xk4_800E8680
+
+D_xk4_800E86C0:
+  type: VTX
+  offset: 0x1F2430
+  count: 4
+  symbol: D_xk4_800E86C0
+
+D_xk4_800E8700:
+  type: VTX
+  offset: 0x1F2470
+  count: 3
+  symbol: D_xk4_800E8700
+
+D_xk4_800E8730:
+  type: VTX
+  offset: 0x1F24A0
+  count: 10
+  symbol: D_xk4_800E8730
+
+D_xk4_800E87D0:
+  type: VTX
+  offset: 0x1F2540
+  count: 7
+  symbol: D_xk4_800E87D0
+
+D_xk4_800E8840:
+  type: VTX
+  offset: 0x1F25B0
+  count: 4
+  symbol: D_xk4_800E8840
+
+D_xk4_800E8880:
+  type: VTX
+  offset: 0x1F25F0
+  count: 12
+  symbol: D_xk4_800E8880
+
+D_xk4_800E8940:
+  type: VTX
+  offset: 0x1F26B0
+  count: 8
+  symbol: D_xk4_800E8940
+
+D_xk4_800E89C0:
+  type: VTX
+  offset: 0x1F2730
+  count: 12
+  symbol: D_xk4_800E89C0
+
+D_xk4_800E8A80:
+  type: VTX
+  offset: 0x1F27F0
+  count: 3
+  symbol: D_xk4_800E8A80
+
+D_xk4_800E8AB0:
+  type: VTX
+  offset: 0x1F2820
+  count: 7
+  symbol: D_xk4_800E8AB0
+
+D_xk4_800E8B20:
+  type: VTX
+  offset: 0x1F2890
+  count: 8
+  symbol: D_xk4_800E8B20
+
+D_xk4_800E8BA0:
+  type: VTX
+  offset: 0x1F2910
+  count: 9
+  symbol: D_xk4_800E8BA0
+
+D_xk4_800E8C30:
+  type: VTX
+  offset: 0x1F29A0
+  count: 5
+  symbol: D_xk4_800E8C30
+
+D_xk4_800E8C80:
+  type: VTX
+  offset: 0x1F29F0
+  count: 6
+  symbol: D_xk4_800E8C80
+
+D_xk4_800E8CE0:
+  type: VTX
+  offset: 0x1F2A50
+  count: 5
+  symbol: D_xk4_800E8CE0
+
+D_xk4_800E8D30:
+  type: VTX
+  offset: 0x1F2AA0
+  count: 4
+  symbol: D_xk4_800E8D30
+
+D_xk4_800E8D70:
+  type: VTX
+  offset: 0x1F2AE0
+  count: 7
+  symbol: D_xk4_800E8D70
+
+D_xk4_800E8DE0:
+  type: VTX
+  offset: 0x1F2B50
+  count: 9
+  symbol: D_xk4_800E8DE0
+
+D_xk4_800E8E70:
+  type: VTX
+  offset: 0x1F2BE0
+  count: 4
+  symbol: D_xk4_800E8E70
+
+D_xk4_800E8EB0:
+  type: GFX
+  offset: 0x1F2C20
+  symbol: D_xk4_800E8EB0
+
+D_xk4_800E8EC0:
+  type: GFX
+  offset: 0x1F2C30
+  symbol: D_xk4_800E8EC0
+
+D_xk4_800E8ED0:
+  type: GFX
+  offset: 0x1F2C40
+  symbol: D_xk4_800E8ED0
+
+D_xk4_800E8F38:
+  type: GFX
+  offset: 0x1F2CA8
+  symbol: D_xk4_800E8F38
+
+D_xk4_800E8F98:
+  type: GFX
+  offset: 0x1F2D08
+  symbol: D_xk4_800E8F98
+
+D_xk4_800E8FF0:
+  type: GFX
+  offset: 0x1F2D60
+  symbol: D_xk4_800E8FF0
+
+D_xk4_800E9048:
+  type: GFX
+  offset: 0x1F2DB8
+  symbol: D_xk4_800E9048
+
+D_xk4_800E90A0:
+  type: GFX
+  offset: 0x1F2E10
+  symbol: D_xk4_800E90A0
+
+D_xk4_800E90F0:
+  type: GFX
+  offset: 0x1F2E60
+  symbol: D_xk4_800E90F0
+
+D_xk4_800E9150:
+  type: GFX
+  offset: 0x1F2EC0
+  symbol: D_xk4_800E9150
+
+D_xk4_800E91C0:
+  type: GFX
+  offset: 0x1F2F30
+  symbol: D_xk4_800E91C0
+
+D_xk4_800E9210:
+  type: GFX
+  offset: 0x1F2F80
+  symbol: D_xk4_800E9210
+
+D_xk4_800E9220:
+  type: GFX
+  offset: 0x1F2F90
+  symbol: D_xk4_800E9220
+
+D_xk4_800E9230:
+  type: GFX
+  offset: 0x1F2FA0
+  symbol: D_xk4_800E9230
+
+D_xk4_800E9288:
+  type: GFX
+  offset: 0x1F2FF8
+  symbol: D_xk4_800E9288
+
+D_xk4_800E92E8:
+  type: GFX
+  offset: 0x1F3058
+  symbol: D_xk4_800E92E8
+
+D_xk4_800E9340:
+  type: GFX
+  offset: 0x1F30B0
+  symbol: D_xk4_800E9340
+
+D_xk4_800E9390:
+  type: GFX
+  offset: 0x1F3100
+  symbol: D_xk4_800E9390
+
+D_xk4_800E93F8:
+  type: GFX
+  offset: 0x1F3168
+  symbol: D_xk4_800E93F8
+
+D_xk4_800E9458:
+  type: GFX
+  offset: 0x1F31C8
+  symbol: D_xk4_800E9458
+
+D_xk4_800E94D0:
+  type: GFX
+  offset: 0x1F3240
+  symbol: D_xk4_800E94D0
+
+D_xk4_800E94E0:
+  type: GFX
+  offset: 0x1F3250
+  symbol: D_xk4_800E94E0
+
+D_xk4_800E95A0:
+  type: GFX
+  offset: 0x1F3310
+  symbol: D_xk4_800E95A0
+
+D_xk4_800E95F8:
+  type: GFX
+  offset: 0x1F3368
+  symbol: D_xk4_800E95F8
+
+D_xk4_800E9608:
+  type: GFX
+  offset: 0x1F3378
+  symbol: D_xk4_800E9608
+
+D_xk4_800E9618:
+  type: GFX
+  offset: 0x1F3388
+  symbol: D_xk4_800E9618
+
+D_xk4_800E9680:
+  type: GFX
+  offset: 0x1F33F0
+  symbol: D_xk4_800E9680
+
+D_xk4_800E96E0:
+  type: GFX
+  offset: 0x1F3450
+  symbol: D_xk4_800E96E0
+
+D_xk4_800E9738:
+  type: GFX
+  offset: 0x1F34A8
+  symbol: D_xk4_800E9738
+
+D_xk4_800E9790:
+  type: GFX
+  offset: 0x1F3500
+  symbol: D_xk4_800E9790
+
+D_xk4_800E97E8:
+  type: GFX
+  offset: 0x1F3558
+  symbol: D_xk4_800E97E8
+
+D_xk4_800E9838:
+  type: GFX
+  offset: 0x1F35A8
+  symbol: D_xk4_800E9838
+
+D_xk4_800E9898:
+  type: GFX
+  offset: 0x1F3608
+  symbol: D_xk4_800E9898
+
+D_xk4_800E9908:
+  type: GFX
+  offset: 0x1F3678
+  symbol: D_xk4_800E9908
+
+D_xk4_800E9958:
+  type: GFX
+  offset: 0x1F36C8
+  symbol: D_xk4_800E9958
+
+D_xk4_800E9968:
+  type: GFX
+  offset: 0x1F36D8
+  symbol: D_xk4_800E9968
+
+D_xk4_800E9978:
+  type: GFX
+  offset: 0x1F36E8
+  symbol: D_xk4_800E9978
+
+D_xk4_800E99D0:
+  type: GFX
+  offset: 0x1F3740
+  symbol: D_xk4_800E99D0
+
+D_xk4_800E9A30:
+  type: GFX
+  offset: 0x1F37A0
+  symbol: D_xk4_800E9A30
+
+D_xk4_800E9A88:
+  type: GFX
+  offset: 0x1F37F8
+  symbol: D_xk4_800E9A88
+
+D_xk4_800E9AD8:
+  type: GFX
+  offset: 0x1F3848
+  symbol: D_xk4_800E9AD8
+
+D_xk4_800E9B40:
+  type: GFX
+  offset: 0x1F38B0
+  symbol: D_xk4_800E9B40
+
+D_xk4_800E9BA0:
+  type: GFX
+  offset: 0x1F3910
+  symbol: D_xk4_800E9BA0
+
+D_xk4_800E9C18:
+  type: GFX
+  offset: 0x1F3988
+  symbol: D_xk4_800E9C18
+
+D_xk4_800E9C28:
+  type: GFX
+  offset: 0x1F3998
+  symbol: D_xk4_800E9C28
+
+D_xk4_800E9CE8:
+  type: GFX
+  offset: 0x1F3A58
+  symbol: D_xk4_800E9CE8
+
+D_xk4_800E9D40:
+  type: GFX
+  offset: 0x1F3AB0
+  symbol: D_xk4_800E9D40
+
+D_xk4_800E9D50:
+  type: GFX
+  offset: 0x1F3AC0
+  symbol: D_xk4_800E9D50
+
+D_xk4_800E9D60:
+  type: GFX
+  offset: 0x1F3AD0
+  symbol: D_xk4_800E9D60
+
+D_xk4_800E9D70:
+  type: GFX
+  offset: 0x1F3AE0
+  symbol: D_xk4_800E9D70
+
+D_xk4_800E9DE0:
+  type: GFX
+  offset: 0x1F3B50
+  symbol: D_xk4_800E9DE0
+
+D_xk4_800E9E40:
+  type: GFX
+  offset: 0x1F3BB0
+  symbol: D_xk4_800E9E40
+
+D_xk4_800E9E90:
+  type: GFX
+  offset: 0x1F3C00
+  symbol: D_xk4_800E9E90
+
+D_xk4_800E9F10:
+  type: GFX
+  offset: 0x1F3C80
+  symbol: D_xk4_800E9F10
+
+D_xk4_800E9FA0:
+  type: GFX
+  offset: 0x1F3D10
+  symbol: D_xk4_800E9FA0
+
+D_xk4_800EA018:
+  type: GFX
+  offset: 0x1F3D88
+  symbol: D_xk4_800EA018
+
+D_xk4_800EA080:
+  type: GFX
+  offset: 0x1F3DF0
+  symbol: D_xk4_800EA080
+
+D_xk4_800EA0D8:
+  type: GFX
+  offset: 0x1F3E48
+  symbol: D_xk4_800EA0D8
+
+D_xk4_800EA0E8:
+  type: GFX
+  offset: 0x1F3E58
+  symbol: D_xk4_800EA0E8
+
+D_xk4_800EA0F8:
+  type: GFX
+  offset: 0x1F3E68
+  symbol: D_xk4_800EA0F8
+
+D_xk4_800EA108:
+  type: GFX
+  offset: 0x1F3E78
+  symbol: D_xk4_800EA108
+
+D_xk4_800EA170:
+  type: GFX
+  offset: 0x1F3EE0
+  symbol: D_xk4_800EA170
+
+D_xk4_800EA1C8:
+  type: GFX
+  offset: 0x1F3F38
+  symbol: D_xk4_800EA1C8
+
+D_xk4_800EA220:
+  type: GFX
+  offset: 0x1F3F90
+  symbol: D_xk4_800EA220
+
+D_xk4_800EA278:
+  type: GFX
+  offset: 0x1F3FE8
+  symbol: D_xk4_800EA278
+
+D_xk4_800EA2D0:
+  type: GFX
+  offset: 0x1F4040
+  symbol: D_xk4_800EA2D0
+
+D_xk4_800EA340:
+  type: GFX
+  offset: 0x1F40B0
+  symbol: D_xk4_800EA340
+
+D_xk4_800EA350:
+  type: GFX
+  offset: 0x1F40C0
+  symbol: D_xk4_800EA350
+
+D_xk4_800EA360:
+  type: GFX
+  offset: 0x1F40D0
+  symbol: D_xk4_800EA360
+
+D_xk4_800EA3E8:
+  type: GFX
+  offset: 0x1F4158
+  symbol: D_xk4_800EA3E8
+
+D_xk4_800EA4A8:
+  type: GFX
+  offset: 0x1F4218
+  symbol: D_xk4_800EA4A8
+
+D_xk4_800EA528:
+  type: GFX
+  offset: 0x1F4298
+  symbol: D_xk4_800EA528
+
+D_xk4_800EA538:
+  type: GFX
+  offset: 0x1F42A8
+  symbol: D_xk4_800EA538
+
+D_xk4_800EA548:
+  type: GFX
+  offset: 0x1F42B8
+  symbol: D_xk4_800EA548
+
+D_xk4_800EA558:
+  type: GFX
+  offset: 0x1F42C8
+  symbol: D_xk4_800EA558
+
+D_xk4_800EA5C8:
+  type: GFX
+  offset: 0x1F4338
+  symbol: D_xk4_800EA5C8
+
+D_xk4_800EA628:
+  type: GFX
+  offset: 0x1F4398
+  symbol: D_xk4_800EA628
+
+D_xk4_800EA678:
+  type: GFX
+  offset: 0x1F43E8
+  symbol: D_xk4_800EA678
+
+D_xk4_800EA6F8:
+  type: GFX
+  offset: 0x1F4468
+  symbol: D_xk4_800EA6F8
+
+D_xk4_800EA788:
+  type: GFX
+  offset: 0x1F44F8
+  symbol: D_xk4_800EA788
+
+D_xk4_800EA800:
+  type: GFX
+  offset: 0x1F4570
+  symbol: D_xk4_800EA800
+
+D_xk4_800EA868:
+  type: GFX
+  offset: 0x1F45D8
+  symbol: D_xk4_800EA868
+
+D_xk4_800EA8C0:
+  type: GFX
+  offset: 0x1F4630
+  symbol: D_xk4_800EA8C0
+
+D_xk4_800EA8D0:
+  type: GFX
+  offset: 0x1F4640
+  symbol: D_xk4_800EA8D0
+
+D_xk4_800EA8E0:
+  type: GFX
+  offset: 0x1F4650
+  symbol: D_xk4_800EA8E0
+
+D_xk4_800EA8F0:
+  type: GFX
+  offset: 0x1F4660
+  symbol: D_xk4_800EA8F0
+
+D_xk4_800EA958:
+  type: GFX
+  offset: 0x1F46C8
+  symbol: D_xk4_800EA958
+
+D_xk4_800EA9B0:
+  type: GFX
+  offset: 0x1F4720
+  symbol: D_xk4_800EA9B0
+
+D_xk4_800EAA08:
+  type: GFX
+  offset: 0x1F4778
+  symbol: D_xk4_800EAA08
+
+D_xk4_800EAA60:
+  type: GFX
+  offset: 0x1F47D0
+  symbol: D_xk4_800EAA60
+
+D_xk4_800EAAB8:
+  type: GFX
+  offset: 0x1F4828
+  symbol: D_xk4_800EAAB8
+
+D_xk4_800EAB28:
+  type: GFX
+  offset: 0x1F4898
+  symbol: D_xk4_800EAB28
+
+D_xk4_800EAB38:
+  type: GFX
+  offset: 0x1F48A8
+  symbol: D_xk4_800EAB38
+
+D_xk4_800EAB48:
+  type: GFX
+  offset: 0x1F48B8
+  symbol: D_xk4_800EAB48
+
+D_xk4_800EABD0:
+  type: GFX
+  offset: 0x1F4940
+  symbol: D_xk4_800EABD0
+
+D_xk4_800EAC90:
+  type: GFX
+  offset: 0x1F4A00
+  symbol: D_xk4_800EAC90
+
+D_xk4_800EAD10:
+  type: GFX
+  offset: 0x1F4A80
+  symbol: D_xk4_800EAD10
+
+D_xk4_800EAD20:
+  type: GFX
+  offset: 0x1F4A90
+  symbol: D_xk4_800EAD20
+
+D_xk4_800EAD30:
+  type: GFX
+  offset: 0x1F4AA0
+  symbol: D_xk4_800EAD30
+
+D_xk4_800EADB0:
+  type: GFX
+  offset: 0x1F4B20
+  symbol: D_xk4_800EADB0
+
+D_xk4_800EAE08:
+  type: GFX
+  offset: 0x1F4B78
+  symbol: D_xk4_800EAE08
+
+D_xk4_800EAE60:
+  type: GFX
+  offset: 0x1F4BD0
+  symbol: D_xk4_800EAE60
+
+D_xk4_800EAF58:
+  type: GFX
+  offset: 0x1F4CC8
+  symbol: D_xk4_800EAF58
+
+D_xk4_800EAFE0:
+  type: GFX
+  offset: 0x1F4D50
+  symbol: D_xk4_800EAFE0
+
+D_xk4_800EB080:
+  type: GFX
+  offset: 0x1F4DF0
+  symbol: D_xk4_800EB080
+
+D_xk4_800EB0D8:
+  type: GFX
+  offset: 0x1F4E48
+  symbol: D_xk4_800EB0D8
+
+D_xk4_800EB0E8:
+  type: GFX
+  offset: 0x1F4E58
+  symbol: D_xk4_800EB0E8
+
+D_xk4_800EB0F8:
+  type: GFX
+  offset: 0x1F4E68
+  symbol: D_xk4_800EB0F8
+
+D_xk4_800EB1B0:
+  type: GFX
+  offset: 0x1F4F20
+  symbol: D_xk4_800EB1B0
+
+D_xk4_800EB220:
+  type: GFX
+  offset: 0x1F4F90
+  symbol: D_xk4_800EB220
+
+D_xk4_800EB2C0:
+  type: GFX
+  offset: 0x1F5030
+  symbol: D_xk4_800EB2C0
+
+D_xk4_800EB408:
+  type: GFX
+  offset: 0x1F5178
+  symbol: D_xk4_800EB408
+
+D_xk4_800EB4F8:
+  type: GFX
+  offset: 0x1F5268
+  symbol: D_xk4_800EB4F8
+
+D_xk4_800EB588:
+  type: GFX
+  offset: 0x1F52F8
+  symbol: D_xk4_800EB588
+
+D_xk4_800EB5D8:
+  type: GFX
+  offset: 0x1F5348
+  symbol: D_xk4_800EB5D8
+
+D_xk4_800EB648:
+  type: GFX
+  offset: 0x1F53B8
+  symbol: D_xk4_800EB648
+
+D_xk4_800EB6E8:
+  type: GFX
+  offset: 0x1F5458
+  symbol: D_xk4_800EB6E8
+
+D_xk4_800EB738:
+  type: GFX
+  offset: 0x1F54A8
+  symbol: D_xk4_800EB738
+
+D_xk4_800EB840:
+  type: GFX
+  offset: 0x1F55B0
+  symbol: D_xk4_800EB840
+
+D_xk4_800EB9B8:
+  type: GFX
+  offset: 0x1F5728
+  symbol: D_xk4_800EB9B8
+
+D_xk4_800EBA58:
+  type: GFX
+  offset: 0x1F57C8
+  symbol: D_xk4_800EBA58
+
+D_xk4_800EBAC8:
+  type: GFX
+  offset: 0x1F5838
+  symbol: D_xk4_800EBAC8
+
+D_xk4_800EBB48:
+  type: GFX
+  offset: 0x1F58B8
+  symbol: D_xk4_800EBB48
+
+D_xk4_800EBBE0:
+  type: GFX
+  offset: 0x1F5950
+  symbol: D_xk4_800EBBE0
+
+D_xk4_800EBC00:
+  type: GFX
+  offset: 0x1F5970
+  symbol: D_xk4_800EBC00
+
+D_xk4_800EBC48:
+  type: GFX
+  offset: 0x1F59B8
+  symbol: D_xk4_800EBC48
+
+D_xk4_800EBC68:
+  type: GFX
+  offset: 0x1F59D8
+  symbol: D_xk4_800EBC68
+
+D_xk4_800EBCA0:
+  type: GFX
+  offset: 0x1F5A10
+  symbol: D_xk4_800EBCA0
+
+D_xk4_800EBCB8:
+  type: GFX
+  offset: 0x1F5A28
+  symbol: D_xk4_800EBCB8
+
+D_xk4_800EBCD8:
+  type: GFX
+  offset: 0x1F5A48
+  symbol: D_xk4_800EBCD8
+
+D_xk4_800EBCF8:
+  type: GFX
+  offset: 0x1F5A68
+  symbol: D_xk4_800EBCF8
+
+D_xk4_800EBD40:
+  type: GFX
+  offset: 0x1F5AB0
+  symbol: D_xk4_800EBD40
+
+D_xk4_800EBD60:
+  type: GFX
+  offset: 0x1F5AD0
+  symbol: D_xk4_800EBD60
+
+D_xk4_800EBD98:
+  type: GFX
+  offset: 0x1F5B08
+  symbol: D_xk4_800EBD98
+
+D_xk4_800EBDB0:
+  type: GFX
+  offset: 0x1F5B20
+  symbol: D_xk4_800EBDB0
+
+D_xk4_800EBDD0:
+  type: GFX
+  offset: 0x1F5B40
+  symbol: D_xk4_800EBDD0
+
+D_xk4_800EBDE8:
+  type: GFX
+  offset: 0x1F5B58
+  symbol: D_xk4_800EBDE8
+
+D_xk4_800EBE28:
+  type: GFX
+  offset: 0x1F5B98
+  symbol: D_xk4_800EBE28
+
+D_xk4_800EBE40:
+  type: GFX
+  offset: 0x1F5BB0
+  symbol: D_xk4_800EBE40
+
+D_xk4_800EBEA8:
+  type: GFX
+  offset: 0x1F5C18
+  symbol: D_xk4_800EBEA8
+
+D_xk4_800EBEC0:
+  type: GFX
+  offset: 0x1F5C30
+  symbol: D_xk4_800EBEC0
+
+D_xk4_800EBF10:
+  type: GFX
+  offset: 0x1F5C80
+  symbol: D_xk4_800EBF10
+
+D_xk4_800EBF28:
+  type: GFX
+  offset: 0x1F5C98
+  symbol: D_xk4_800EBF28
+
+D_xk4_800EBF68:
+  type: GFX
+  offset: 0x1F5CD8
+  symbol: D_xk4_800EBF68
+
+D_xk4_800EBF78:
+  type: GFX
+  offset: 0x1F5CE8
+  symbol: D_xk4_800EBF78
+
+D_xk4_800EBF90:
+  type: GFX
+  offset: 0x1F5D00
+  symbol: D_xk4_800EBF90
+
+D_xk4_800EBFA8:
+  type: GFX
+  offset: 0x1F5D18
+  symbol: D_xk4_800EBFA8
+
+D_xk4_800EBFF8:
+  type: GFX
+  offset: 0x1F5D68
+  symbol: D_xk4_800EBFF8
+
+D_xk4_800EC010:
+  type: GFX
+  offset: 0x1F5D80
+  symbol: D_xk4_800EC010
+
+D_xk4_800EC050:
+  type: GFX
+  offset: 0x1F5DC0
+  symbol: D_xk4_800EC050
+
+D_xk4_800EC060:
+  type: GFX
+  offset: 0x1F5DD0
+  symbol: D_xk4_800EC060
+
+D_xk4_800EC078:
+  type: GFX
+  offset: 0x1F5DE8
+  symbol: D_xk4_800EC078

--- a/assets/yaml/jp/overlays/ovl_xk4/ending_dd_animation.yaml
+++ b/assets/yaml/jp/overlays/ovl_xk4/ending_dd_animation.yaml
@@ -1,0 +1,55 @@
+:config:
+  header:
+    code:
+      - '#include "assets/overlays/ovl_xk4/ending_dd_animation.h"'
+    header:
+      - '#include "libultra/ultra64.h"'
+
+D_xk4_800D8AA0:
+  type: ARRAY
+  array_type: f32
+  count: 3
+  offset: 0x1E2810
+  symbol: D_xk4_800D8AA0
+
+D_xk4_800D8AAC:
+  type: ARRAY
+  array_type: s16
+  count: 1372
+  offset: 0x1E281C
+  symbol: D_xk4_800D8AAC
+
+D_xk4_800D9564:
+  type: ARRAY
+  array_type: s16
+  count: 108
+  offset: 0x1E32D4
+  symbol: D_xk4_800D9564
+
+D_xk4_800D963C:
+  type: ARRAY
+  array_type: s32
+  count: 252
+  offset: 0x1E33AC
+  symbol: D_xk4_800D963C
+
+D_xk4_800D9A2C:
+  type: ARRAY
+  array_type: s32
+  count: 252
+  offset: 0x1E379C
+  symbol: D_xk4_800D9A2C
+
+D_xk4_800D9E1C:
+  type: ARRAY
+  array_type: s32
+  count: 252
+  offset: 0x1E3B8C
+  symbol: D_xk4_800D9E1C
+
+D_xk4_800DA20C:
+  type: ARRAY
+  array_type: f32
+  count: 8
+  offset: 0x1E3F7C
+  symbol: D_xk4_800DA20C

--- a/assets/yaml/jp/overlays/ovl_xk4/ending_dd_congratulations.yaml
+++ b/assets/yaml/jp/overlays/ovl_xk4/ending_dd_congratulations.yaml
@@ -1,0 +1,15 @@
+:config:
+  header:
+    code:
+      - '#include "assets/overlays/ovl_xk4/ending_dd_congratulations.h"'
+    header:
+      - '#include "libultra/ultra64.h"'
+
+D_xk4_800ECA78:
+  type: TEXTURE
+  ctype: u16
+  format: RGBA16
+  width: 160
+  height: 64
+  offset: 0x1F67E8
+  symbol: D_xk4_800ECA78

--- a/src/overlays/ovl_xk4/1E0B00.c
+++ b/src/overlays/ovl_xk4/1E0B00.c
@@ -1,42 +1,447 @@
-#include "common.h"
+#include "global.h"
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D6D90.s")
+#define PHYSICAL_TO_VIRTUAL(x) (((uintptr_t)x)+0x80000000)
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D6F38.s")
+f32 func_xk4_800D6D90(f32 arg0) {
+    s32 i;
+    f64 var_fv1 = arg0;
+    f64 var_fa1 = -var_fv1 * var_fv1 * var_fv1;
+    f64 var_ft4 = -var_fv1 * var_fv1;
+    f64 var_ft5 = 6.0;
+    f64 var_fa0;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D6FD0.s")
+    for (i = 2; i < 14; i++) {
+        var_fa0 = var_fa1 / var_ft5;
+        var_fa1 *= var_ft4;
+        var_ft5 *= i * ((i << 2) + 2);
+        var_fv1 += var_fa0;
+    }
+    return var_fv1;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D71DC.s")
+extern f32 D_800F1AE0[];
+extern f32 D_xk4_800F2AE0[];
+extern f32* D_xk4_800F6AE0;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7454.s")
+void func_xk4_800D6F38(void) {
+    s32 i;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D74A4.s")
+    for (i = 0; i < 0x1400; i++) {
+        D_800F1AE0[i] = func_xk4_800D6D90(2.0f * (((f32)i / 4096) * 3.1415927f));
+    }
+    D_xk4_800F6AE0 = D_xk4_800F2AE0;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7504.s")
+void func_xk4_800D6FD0(Mtx* arg0, MtxF* arg1) {
+    s32 temp_ft2;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D751C.s")
+    temp_ft2 = arg1->m[3][3] * 65536.0f;
+    arg0->u.i[3][3] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[3][3] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[3][2] * 65536.0f;
+    arg0->u.i[2][3] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[2][3] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[3][1] * 65536.0f;
+    arg0->u.i[1][3] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[1][3] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[3][0] * 65536.0f;
+    arg0->u.i[0][3] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[0][3] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[2][3] * 65536.0f;
+    arg0->u.i[3][2] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[3][2] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[2][2] * 65536.0f;
+    arg0->u.i[2][2] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[2][2] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[2][1] * 65536.0f;
+    arg0->u.i[1][2] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[1][2] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[2][0] * 65536.0f;
+    arg0->u.i[0][2] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[0][2] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[1][3] * 65536.0f;
+    arg0->u.i[3][1] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[3][1] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[1][2] * 65536.0f;
+    arg0->u.i[2][1] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[2][1] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[1][1] * 65536.0f;
+    arg0->u.i[1][1] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[1][1] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[1][0] * 65536.0f;
+    arg0->u.i[0][1] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[0][1] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[0][3] * 65536.0f;
+    arg0->u.i[3][0] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[3][0] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[0][2] * 65536.0f;
+    arg0->u.i[2][0] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[2][0] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[0][1] * 65536.0f;
+    arg0->u.i[1][0] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[1][0] = temp_ft2 & 0xFFFF;
+    temp_ft2 = arg1->m[0][0] * 65536.0f;
+    arg0->u.i[0][0] = ((u32) temp_ft2 >> 0x10);
+    arg0->u.f[0][0] = temp_ft2 & 0xFFFF;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7530.s")
+void func_xk4_800D71DC(MtxF* arg0, MtxF* arg1, MtxF* arg2) {
+    arg0->m[0][0] = (arg1->m[0][0] * arg2->m[0][0]) + (arg1->m[0][1] * arg2->m[1][0]) + (arg1->m[0][2] * arg2->m[2][0]);
+    arg0->m[0][1] = (arg1->m[0][0] * arg2->m[0][1]) + (arg1->m[0][1] * arg2->m[1][1]) + (arg1->m[0][2] * arg2->m[2][1]);
+    arg0->m[0][2] = (arg1->m[0][0] * arg2->m[0][2]) + (arg1->m[0][1] * arg2->m[1][2]) + (arg1->m[0][2] * arg2->m[2][2]);
+    arg0->m[0][3] = (arg1->m[0][0] * arg2->m[0][3]) + (arg1->m[0][1] * arg2->m[1][3]) + (arg1->m[0][2] * arg2->m[2][3]) + arg1->m[0][3];
+    arg0->m[1][0] = (arg1->m[1][0] * arg2->m[0][0]) + (arg1->m[1][1] * arg2->m[1][0]) + (arg1->m[1][2] * arg2->m[2][0]);
+    arg0->m[1][1] = (arg1->m[1][0] * arg2->m[0][1]) + (arg1->m[1][1] * arg2->m[1][1]) + (arg1->m[1][2] * arg2->m[2][1]);
+    arg0->m[1][2] = (arg1->m[1][0] * arg2->m[0][2]) + (arg1->m[1][1] * arg2->m[1][2]) + (arg1->m[1][2] * arg2->m[2][2]);
+    arg0->m[1][3] = (arg1->m[1][0] * arg2->m[0][3]) + (arg1->m[1][1] * arg2->m[1][3]) + (arg1->m[1][2] * arg2->m[2][3]) + arg1->m[1][3];
+    arg0->m[2][0] = (arg1->m[2][0] * arg2->m[0][0]) + (arg1->m[2][1] * arg2->m[1][0]) + (arg1->m[2][2] * arg2->m[2][0]);
+    arg0->m[2][1] = (arg1->m[2][0] * arg2->m[0][1]) + (arg1->m[2][1] * arg2->m[1][1]) + (arg1->m[2][2] * arg2->m[2][1]);
+    arg0->m[2][2] = (arg1->m[2][0] * arg2->m[0][2]) + (arg1->m[2][1] * arg2->m[1][2]) + (arg1->m[2][2] * arg2->m[2][2]);
+    arg0->m[2][3] = (arg1->m[2][0] * arg2->m[0][3]) + (arg1->m[2][1] * arg2->m[1][3]) + (arg1->m[2][2] * arg2->m[2][3]) + arg1->m[2][3];
+    arg0->m[3][0] = 0.0f;
+    arg0->m[3][1] = 0.0f;
+    arg0->m[3][2] = 0.0f;
+    arg0->m[3][3] = 1.0f;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7860.s")
+void func_xk4_800D7454(MtxF* arg0) {
+    arg0->m[0][0] = arg0->m[1][1] = arg0->m[2][2] = arg0->m[3][3] = 1.0f;
+    arg0->m[0][1] = arg0->m[0][2] = arg0->m[0][3] = arg0->m[1][0] = arg0->m[1][2] = arg0->m[1][3] = arg0->m[2][0] = arg0->m[2][1] = arg0->m[2][3] = arg0->m[3][0] = arg0->m[3][1] = arg0->m[3][2] = 0.0f;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7894.s")
+void func_xk4_800D74A4(MtxF* arg0, f32 arg1, f32 arg2, f32 arg3) {
+    arg0->m[0][0] = arg1;
+    arg0->m[1][1] = arg2;
+    arg0->m[2][2] = arg3;
+    arg0->m[0][1] = 0.0f;
+    arg0->m[0][2] = 0.0f;
+    arg0->m[1][0] = 0.0f;
+    arg0->m[1][2] = 0.0f;
+    arg0->m[2][0] = 0.0f;
+    arg0->m[2][1] = 0.0f;
+    arg0->m[3][0] = 0.0f;
+    arg0->m[3][1] = 0.0f;
+    arg0->m[3][2] = 0.0f;
+    arg0->m[0][3] = 0.0f;
+    arg0->m[1][3] = 0.0f;
+    arg0->m[2][3] = 0.0f;
+    arg0->m[3][3] = 1.0f;
+}
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7918.s")
+extern s32 D_xk4_800F6AF0[];
+
+s32 func_xk4_800D7504(s32 arg0, s32 arg1) {
+    D_xk4_800F6AF0[arg0] = arg1;
+    return arg1;
+}
+
+s32 func_xk4_800D751C(s32 arg0) {
+    return D_xk4_800F6AF0[arg0];
+}
+
+Gfx* func_xk4_800D7530(Gfx* gfx, FrameBuffer* arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5, s32 arg6, s32 arg7) {
+    s32 color;
+    s32 i;
+    s32 r;
+    s32 g;
+    s32 b;
+
+    gDPPipeSync(gfx++);
+    gDPSetCycleType(gfx++, G_CYC_FILL);
+    gDPSetColorImage(gfx++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, PHYSICAL_TO_VIRTUAL(arg1));
+    gDPSetScissor(gfx++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+
+    for (i = 8; i < 232; i++) {
+        gDPPipeSync(gfx++);
+        r = ((arg2 * (239 - i)) / 239) + ((arg5 * i) / 239);
+        g = ((arg3 * (239 - i)) / 239) + ((arg6 * i) / 239);
+        b = ((arg4 * (239 - i)) / 239) + ((arg7 * i) / 239);
+        gDPSetFillColor(gfx++, GPACK_RGBA5551(r, g, b, 1) << 16 | GPACK_RGBA5551(r, g, b, 1));
+        gDPFillRectangle(gfx++, 12, i, 307, i);
+    }
+    gDPPipeSync(gfx++);
+    gDPSetCycleType(gfx++, G_CYC_1CYCLE);
+    gDPSetScissor(gfx++, G_SC_NON_INTERLACE, 12, 8, 308, 232);
+
+    return gfx;
+}
+
+extern u32 gSegments[];
+
+intptr_t func_xk4_800D7860(uintptr_t segmentedAddr) {
+    return PHYSICAL_TO_VIRTUAL(gSegments[SEGMENT_NUMBER(segmentedAddr)] + SEGMENT_OFFSET(segmentedAddr));
+}
+
+void func_xk4_800D7894(s32* arg0, s32 arg1) {
+    s32 sp1C;
+    s32* temp;
+    s16 temp_a0;
+
+    sp1C = arg0[0];
+    temp = (s32*)func_xk4_800D7860(arg0[3]);
+    temp_a0 = *(s16*)func_xk4_800D7860(temp[sp1C]);
+
+    arg0[1] += arg1;
+    if (arg0[1] >= temp_a0) {
+        arg0[1] -= temp_a0;
+    } else if (arg0[1] < 0) {
+        arg0[1] += temp_a0;
+    }
+}
+
+void func_xk4_800D7918(MtxF* arg0, s16 arg1, s16 arg2, s16 arg3, f32 arg4, f32 arg5, f32 arg6) {
+    f32 temp_fa0;
+    f32 temp_fa1;
+    f32 temp_ft4;
+    f32 temp_ft5;
+    f32 temp_fv0;
+    f32 temp_fv1;
+    s32 var_v0;
+    s32 pad;
+
+    var_v0 = (arg1 << 0xC) >> 0x10;
+    if (var_v0 < 0) {
+        var_v0 += 0x1000;
+    }
+    temp_fv0 = D_800F1AE0[var_v0];
+    temp_fv1 = D_xk4_800F6AE0[var_v0];
+
+    var_v0 = (arg2 << 0xC) >> 0x10;
+    if (var_v0 < 0) {
+        var_v0 += 0x1000;
+    }
+    temp_fa0 = D_800F1AE0[var_v0];
+    temp_fa1 = D_xk4_800F6AE0[var_v0];
+
+    var_v0 = (arg3 << 0xC) >> 0x10;
+    if (var_v0 < 0) {
+        var_v0 += 0x1000;
+    }
+    temp_ft4 = D_800F1AE0[var_v0];
+    temp_ft5 = D_xk4_800F6AE0[var_v0];
+
+    arg0->m[0][0] = temp_fa1 * temp_ft5;
+    arg0->m[1][0] = temp_fa1 * temp_ft4;
+    arg0->m[2][0] = -temp_fa0;
+    arg0->m[0][1] = (temp_fv0 * temp_fa0 * temp_ft5) - (temp_fv1 * temp_ft4);
+    arg0->m[1][1] = (temp_fv0 * temp_fa0 * temp_ft4) + (temp_fv1 * temp_ft5);
+    arg0->m[2][1] = temp_fv0 * temp_fa1;
+    arg0->m[0][2] = (temp_fv1 * temp_fa0 * temp_ft5) + (temp_fv0 * temp_ft4);
+    arg0->m[1][2] = (temp_fv1 * temp_fa0 * temp_ft4) - (temp_fv0 * temp_ft5);
+    arg0->m[2][2] = temp_fv1 * temp_fa1;
+    arg0->m[0][3] = arg4;
+    arg0->m[1][3] = arg5;
+    arg0->m[2][3] = arg6;
+    arg0->m[3][0] = 0.0f;
+    arg0->m[3][1] = 0.0f;
+    arg0->m[3][2] = 0.0f;
+    arg0->m[3][3] = 1.0f;
+}
 
 void func_xk4_800D7AAC(void) {
 }
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7AB4.s")
+extern s16 D_xk4_800F6B30;
+extern s32(*D_xk4_800F6B34)[6];
+extern s32(*D_xk4_800F6B38)[6];
+extern s32(*D_xk4_800F6B3C)[6];
+extern f32* D_xk4_800F6B40;
+extern s16* D_xk4_800F6B44;
+extern s16* D_xk4_800F6B48;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D7E68.s")
+typedef struct unk_800D7AB4 {
+    Gfx* unk_00;
+    Vec3f unk_04;
+    Vec3f unk_10;
+    Vec3s unk_1C;
+    s32 unk_24;
+    s32 unk_28;
+    void* unk_2C;
+    Gfx* unk_30;
+    s16 unk_34;
+} unk_800D7AB4;
 
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D80E8.s")
+void func_xk4_800D7AB4(unk_800D7AB4* arg0, s32 arg1) {
+    s32 temp_a2;
+    s32 temp_a3;
+    s32 temp_t0;
+    s32 temp_t1;
+    s32 temp_t2;
+    s32 temp_v1;
+    s32* temp_v0;
 
+    temp_v0 = &D_xk4_800F6B34[D_xk4_800F6B30];
+    temp_v1 = *temp_v0++;
+    temp_a2 = *temp_v0++;
+    temp_a3 = *temp_v0++;
+    temp_t0 = *temp_v0++;
+    temp_t1 = *temp_v0++;
+    temp_t2 = *temp_v0++;
+
+    if (arg1 < temp_v1) {
+        arg0->unk_04.x = D_xk4_800F6B40[temp_a2 + arg1];
+    } else {
+        arg0->unk_04.x = D_xk4_800F6B40[temp_a2 + temp_v1 - 1];
+    }
+    if (arg1 < temp_a3) {
+        arg0->unk_04.y = D_xk4_800F6B40[temp_t0 + arg1];
+    } else {
+        arg0->unk_04.y = D_xk4_800F6B40[temp_t0 + temp_a3 - 1];
+    }
+    if (arg1 < temp_t1) {
+        arg0->unk_04.z = D_xk4_800F6B40[temp_t2 + arg1];
+    } else {
+        arg0->unk_04.z = D_xk4_800F6B40[temp_t2 + temp_t1 - 1];
+    }
+    temp_v0 = &D_xk4_800F6B38[D_xk4_800F6B30];
+    temp_v1 = *temp_v0++;
+    temp_a2 = *temp_v0++;
+    temp_a3 = *temp_v0++;
+    temp_t0 = *temp_v0++;
+    temp_t1 = *temp_v0++;
+    temp_t2 = *temp_v0++;
+
+    if (arg1 < temp_v1) {
+        arg0->unk_1C.x = D_xk4_800F6B44[temp_a2 + arg1];
+    } else {
+        arg0->unk_1C.x = D_xk4_800F6B44[temp_a2 + temp_v1 - 1];
+    }
+    if (arg1 < temp_a3) {
+        arg0->unk_1C.y = D_xk4_800F6B44[temp_t0 + arg1];
+    } else {
+        arg0->unk_1C.y = D_xk4_800F6B44[temp_t0 + temp_a3 - 1];
+    }
+    if (arg1 < temp_t1) {
+        arg0->unk_1C.z = D_xk4_800F6B44[temp_t2 + arg1];
+    } else {
+        arg0->unk_1C.z = D_xk4_800F6B44[temp_t2 + temp_t1 - 1];
+    }
+    temp_v0 = &D_xk4_800F6B3C[D_xk4_800F6B30];
+    temp_v1 = *temp_v0++;
+    temp_a2 = *temp_v0++;
+    temp_a3 = *temp_v0++;
+    temp_t0 = *temp_v0++;
+    temp_t1 = *temp_v0++;
+    temp_t2 = *temp_v0++;
+
+    if (arg1 < temp_v1) {
+        arg0->unk_10.x = D_xk4_800F6B48[temp_a2 + arg1];
+    } else {
+        arg0->unk_10.x = D_xk4_800F6B48[temp_a2 + temp_v1 - 1];
+    }
+    if (arg1 < temp_a3) {
+        arg0->unk_10.y = D_xk4_800F6B48[temp_t0 + arg1];
+    } else {
+        arg0->unk_10.y = D_xk4_800F6B48[temp_t0 + temp_a3 - 1];
+    }
+    if (arg1 < temp_t1) {
+        arg0->unk_10.z = D_xk4_800F6B48[temp_t2 + arg1];
+    } else {
+        arg0->unk_10.z = D_xk4_800F6B48[temp_t2 + temp_t1 - 1];
+    }
+}
+
+void func_xk4_800D7E58 (void) {
+}
+
+void func_xk4_800D7E60 (void) {
+}
+
+extern Mtx* D_xk4_800F6B4C;
+extern Gfx* D_xk4_800F6AE4;
+
+void func_xk4_800D7E68(s32 arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
+    unk_800D7AB4* temp_v0;
+    MtxF sp104;
+    MtxF spC4;
+    MtxF sp84;
+    s32 temp_s3;
+    Vec3f sp74;
+
+    while (arg0 != 0) {
+        temp_v0 = (unk_800D7AB4*)func_xk4_800D7860(arg0);
+        if ((temp_v0->unk_2C != NULL) && (temp_v0->unk_30 != NULL)) {
+            temp_s3 = ((unk_800D7AB4*)func_xk4_800D7860(temp_v0->unk_2C))->unk_34;
+            
+            gSPMatrix(D_xk4_800F6AE4++, &D_xk4_800F6B4C[temp_s3], G_MTX_PUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+
+            gSPDisplayList(D_xk4_800F6AE4++, temp_v0->unk_30);
+            gSPPopMatrix(D_xk4_800F6AE4++, G_MTX_MODELVIEW);
+        }
+        temp_s3 = temp_v0->unk_34;
+        func_xk4_800D7AB4(temp_v0, arg3);
+        func_xk4_800D7918(&sp104, temp_v0->unk_1C.x, temp_v0->unk_1C.y, temp_v0->unk_1C.z, temp_v0->unk_10.x * arg2->x, temp_v0->unk_10.y * arg2->y, temp_v0->unk_10.z * arg2->z);
+        sp74.x = arg2->x * temp_v0->unk_04.x;
+        sp74.y = arg2->y * temp_v0->unk_04.y;
+        sp74.z = arg2->z * temp_v0->unk_04.z;
+        func_xk4_800D71DC(&spC4, arg1, &sp104);
+        func_xk4_800D74A4(&sp84, sp74.x, sp74.y, sp74.z);
+        func_xk4_800D71DC(&sp104, &spC4, &sp84);
+
+        func_xk4_800D6FD0(&D_xk4_800F6B4C[temp_s3], &sp104);
+        gSPMatrix(D_xk4_800F6AE4++, &D_xk4_800F6B4C[temp_s3], G_MTX_PUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+
+        if (temp_v0->unk_00 != NULL) {
+            gSPDisplayList(D_xk4_800F6AE4++, temp_v0->unk_00);
+        }
+
+        gSPPopMatrix(D_xk4_800F6AE4++, G_MTX_MODELVIEW);
+        D_xk4_800F6B30++;
+        arg0 = temp_v0->unk_28;
+        if (arg0 != 0) {
+            func_xk4_800D7E68(arg0, &spC4, &sp74, arg3);
+        }
+        arg0 = temp_v0->unk_24;
+    }
+}
+
+typedef struct unk_800D80E8 {
+    s8 unk_00[0x4];
+    s32 unk_04;
+    s32 unk_08;
+    s32 unk_0C;
+    s32 unk_10;
+    s32 unk_14;
+    s32 unk_18;
+} unk_800D80E8;
+
+extern Vec3f D_xk4_800F1A7C;
+extern GfxPool* gGfxPool;
+
+void func_xk4_800D80E8(s32 arg0, s32 arg1, s32 arg2) {
+    unk_800D80E8* temp_s0;
+    s32* sp70;
+    MtxF sp30;
+    Vec3f sp24;
+
+    temp_s0 = func_xk4_800D7860(arg1);
+    sp70 = func_xk4_800D7860(arg0);
+    sp24 = D_xk4_800F1A7C;
+    D_xk4_800F6B30 = 0;
+    D_xk4_800F6B34 = func_xk4_800D7860(temp_s0->unk_08);
+    D_xk4_800F6B38 = func_xk4_800D7860(temp_s0->unk_10);
+    D_xk4_800F6B3C = func_xk4_800D7860(temp_s0->unk_18);
+    D_xk4_800F6B40 = func_xk4_800D7860(temp_s0->unk_04);
+    D_xk4_800F6B44 = func_xk4_800D7860(temp_s0->unk_0C);
+    D_xk4_800F6B48 = func_xk4_800D7860(temp_s0->unk_14);
+    D_xk4_800F6B4C = gGfxPool->unk_32308;
+    func_xk4_800D7454(&sp30);
+    func_xk4_800D7E68(*sp70, &sp30, &sp24, arg2);
+}
+
+#ifdef IMPORT_DATA
+extern s32 D_xk4_800DA22C[];
+extern s32 D_xk4_800EC9D0[];
+
+void func_xk4_800D81F4(Gfx** gfxP) {
+    static s32 D_xk4_800F1A88 = 0;
+
+    D_xk4_800F6AE4 = *gfxP;
+    D_xk4_800F1A88 = (D_xk4_800F1A88 + 1) % 40;
+
+    func_xk4_800D80E8(D_xk4_800EC9D0, D_xk4_800DA22C, D_xk4_800F1A88);
+    *gfxP = D_xk4_800F6AE4;
+}
+#else
 #pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D81F4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D8260.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D82A4.s")
-
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D8348.s")
+#endif

--- a/src/overlays/ovl_xk4/1E0B00.c
+++ b/src/overlays/ovl_xk4/1E0B00.c
@@ -1,6 +1,669 @@
 #include "global.h"
+#include "assets/overlays/ovl_xk4/ending_dd_animation.h"
+#include "assets/overlays/ovl_xk4/a1E0B00.h"
+#include "assets/overlays/ovl_xk4/ending_dd_congratulations.h"
 
 #define PHYSICAL_TO_VIRTUAL(x) (((uintptr_t)x)+0x80000000)
+
+typedef struct unk_800D7AB4 {
+    Gfx* unk_00;
+    Vec3f unk_04;
+    Vec3f unk_10;
+    Vec3s unk_1C;
+    struct unk_800D7AB4* unk_24;
+    struct unk_800D7AB4* unk_28;
+    struct unk_800D7AB4* unk_2C;
+    Gfx* unk_30;
+    s16 unk_34;
+} unk_800D7AB4;
+
+typedef struct unk_800D80E8 {
+    s16 unk_00;
+    s16 unk_02;
+    f32* unk_04;
+    s32* unk_08;
+    s16* unk_0C;
+    s32* unk_10;
+    s16* unk_14;
+    s32* unk_18;
+} unk_800D80E8;
+
+extern unk_800D7AB4 D_xk4_800EC998;
+extern unk_800D7AB4 D_xk4_800EC960;
+extern unk_800D7AB4 D_xk4_800EC928;
+extern unk_800D7AB4 D_xk4_800EC8F0;
+extern unk_800D7AB4 D_xk4_800EC8B8;
+extern unk_800D7AB4 D_xk4_800EC880;
+extern unk_800D7AB4 D_xk4_800EC848;
+extern unk_800D7AB4 D_xk4_800EC810;
+extern unk_800D7AB4 D_xk4_800EC7D8;
+extern unk_800D7AB4 D_xk4_800EC7A0;
+extern unk_800D7AB4 D_xk4_800EC768;
+extern unk_800D7AB4 D_xk4_800EC730;
+extern unk_800D7AB4 D_xk4_800EC6F8;
+extern unk_800D7AB4 D_xk4_800EC6C0;
+extern unk_800D7AB4 D_xk4_800EC688;
+extern unk_800D7AB4 D_xk4_800EC650;
+extern unk_800D7AB4 D_xk4_800EC618;
+extern unk_800D7AB4 D_xk4_800EC5E0;
+extern unk_800D7AB4 D_xk4_800EC5A8;
+extern unk_800D7AB4 D_xk4_800EC570;
+extern unk_800D7AB4 D_xk4_800EC538;
+extern unk_800D7AB4 D_xk4_800EC500;
+extern unk_800D7AB4 D_xk4_800EC4C8;
+extern unk_800D7AB4 D_xk4_800EC490;
+extern unk_800D7AB4 D_xk4_800EC458;
+extern unk_800D7AB4 D_xk4_800EC420;
+extern unk_800D7AB4 D_xk4_800EC3E8;
+extern unk_800D7AB4 D_xk4_800EC3B0;
+extern unk_800D7AB4 D_xk4_800EC378;
+extern unk_800D7AB4 D_xk4_800EC340;
+extern unk_800D7AB4 D_xk4_800EC308;
+extern unk_800D7AB4 D_xk4_800EC2D0;
+extern unk_800D7AB4 D_xk4_800EC298;
+extern unk_800D7AB4 D_xk4_800EC260;
+extern unk_800D7AB4 D_xk4_800EC228;
+extern unk_800D7AB4 D_xk4_800EC1F0;
+extern unk_800D7AB4 D_xk4_800EC1B8;
+extern unk_800D7AB4 D_xk4_800EC180;
+extern unk_800D7AB4 D_xk4_800EC148;
+extern unk_800D7AB4 D_xk4_800EC110;
+extern unk_800D7AB4 D_xk4_800EC0D8;
+extern unk_800D7AB4 D_xk4_800EC0A0;
+
+f32 D_800F1AE0[0x1400];
+f32* D_xk4_800F6AE0;
+Gfx* D_xk4_800F6AE4;
+UNUSED s32 D_xk4_800F6AE8;
+UNUSED s32 D_xk4_800F6AEC;
+s32 D_xk4_800F6AF0[16];
+s16 D_xk4_800F6B30;
+s32* D_xk4_800F6B34;
+s32* D_xk4_800F6B38;
+s32* D_xk4_800F6B3C;
+f32* D_xk4_800F6B40;
+s16* D_xk4_800F6B44;
+s16* D_xk4_800F6B48;
+Mtx* D_xk4_800F6B4C;
+UNUSED s32 D_xk4_800F6B50;
+
+// clang-format off
+UNUSED Mtx D_xk4_800D8A60 = {
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+};
+// clang-format on
+
+#include "src/assets/overlays/ovl_xk4/ending_dd_animation/ending_dd_animation.c"
+
+unk_800D80E8 D_xk4_800DA22C = {
+    40, 42,
+    D_xk4_800D8AA0,
+    D_xk4_800D963C,
+    D_xk4_800D8AAC,
+    D_xk4_800D9A2C,
+    D_xk4_800D9564,
+    D_xk4_800D9E1C,
+};
+
+UNUSED s32 D_xk4_800DA248 = 0;
+UNUSED s32 D_xk4_800DA24C = 0;
+
+#include "src/assets/overlays/ovl_xk4/a1E0B00/a1E0B00.c"
+
+// TODO: Extract via Torch
+unk_800D7AB4 D_xk4_800EC0A0 = {
+    D_xk4_800EBC00,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC420,
+    D_xk4_800EBBE0,
+    41,
+};
+
+unk_800D7AB4 D_xk4_800EC0D8 = {
+    D_xk4_800EBC68,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC0A0,
+    D_xk4_800EBC48,
+    40,
+};
+
+unk_800D7AB4 D_xk4_800EC110 = {
+    D_xk4_800EBCB8,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC0D8,
+    D_xk4_800EBCA0,
+    39,
+};
+
+unk_800D7AB4 D_xk4_800EC148 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 450.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC110,
+    NULL,
+    NULL,
+    NULL,
+    38,
+};
+
+unk_800D7AB4 D_xk4_800EC180 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 472.0f, 0.0f, 0.0f },
+    { 0x1C96, 0, 0x1212 },
+    &D_xk4_800EC0D8,
+    &D_xk4_800EC148,
+    NULL,
+    NULL,
+    37,
+};
+
+unk_800D7AB4 D_xk4_800EC1B8 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 571.0f, 0.0f, 0.0f },
+    { 0x2A50, 0x9ED8, 0xD0EE },
+    &D_xk4_800EC0A0,
+    &D_xk4_800EC180,
+    NULL,
+    NULL,
+    36,
+};
+
+unk_800D7AB4 D_xk4_800EC1F0 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0xD5F4, 0xA515 },
+    NULL,
+    &D_xk4_800EC1B8,
+    NULL,
+    NULL,
+    35,
+};
+
+unk_800D7AB4 D_xk4_800EC228 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 667.0f, 374.0f, 0.0f },
+    { 0, 0, 0xBFBD },
+    NULL,
+    &D_xk4_800EC1F0,
+    NULL,
+    NULL,
+    34,
+};
+
+unk_800D7AB4 D_xk4_800EC260 = {
+    D_xk4_800EBCF8,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC420,
+    D_xk4_800EBCD8,
+    33,
+};
+
+unk_800D7AB4 D_xk4_800EC298 = {
+    D_xk4_800EBD60,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC260,
+    D_xk4_800EBD40,
+    32,
+};
+
+unk_800D7AB4 D_xk4_800EC2D0 = {
+    D_xk4_800EBDB0,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC298,
+    D_xk4_800EBD98,
+    31,
+};
+
+unk_800D7AB4 D_xk4_800EC308 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 450.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC2D0,
+    NULL,
+    NULL,
+    NULL,
+    30,
+};
+
+unk_800D7AB4 D_xk4_800EC340 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 472.0f, 0.0f, 0.0f },
+    { 0xFE7B, 0xFF8B, 0xE31F },
+    &D_xk4_800EC298,
+    &D_xk4_800EC308,
+    NULL,
+    NULL,
+    29,
+};
+
+unk_800D7AB4 D_xk4_800EC378 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 571.0f, 0.0f, 0.0f },
+    { 0x8813, 0x7F02, 0x7902 },
+    &D_xk4_800EC260,
+    &D_xk4_800EC340,
+    NULL,
+    NULL,
+    28,
+};
+
+unk_800D7AB4 D_xk4_800EC3B0 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0x8001, 0x8689, 0x235C },
+    NULL,
+    &D_xk4_800EC378,
+    NULL,
+    NULL,
+    27,
+};
+
+unk_800D7AB4 D_xk4_800EC3E8 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 662.0f, -370.0f, 0.0f },
+    { 0, 0x7FFE, 0xBFBD },
+    &D_xk4_800EC228,
+    &D_xk4_800EC3B0,
+    NULL,
+    NULL,
+    26,
+};
+
+unk_800D7AB4 D_xk4_800EC420 = {
+    D_xk4_800EBDE8,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC3E8,
+    NULL,
+    &D_xk4_800EC8F0,
+    D_xk4_800EBDD0,
+    25,
+};
+
+unk_800D7AB4 D_xk4_800EC458 = {
+    D_xk4_800EBE40,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC420,
+    D_xk4_800EBE28,
+    24,
+};
+
+unk_800D7AB4 D_xk4_800EC490 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 522.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC458,
+    NULL,
+    NULL,
+    NULL,
+    23,
+};
+
+unk_800D7AB4 D_xk4_800EC4C8 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 682.0f, 0.0f, 0.0f },
+    { 0x0507, 0xFE2F, 0x02E8 },
+    &D_xk4_800EC420,
+    &D_xk4_800EC490,
+    NULL,
+    NULL,
+    22,
+};
+
+unk_800D7AB4 D_xk4_800EC500 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0xFAEE, 0, 0x42EB },
+    NULL,
+    &D_xk4_800EC4C8,
+    NULL,
+    NULL,
+    21,
+};
+
+unk_800D7AB4 D_xk4_800EC538 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { -93.0f, -1.0f, 0.0f },
+    { 0, 0, 0x407A },
+    NULL,
+    &D_xk4_800EC500,
+    NULL,
+    NULL,
+    20,
+};
+
+unk_800D7AB4 D_xk4_800EC570 = {
+    D_xk4_800EBEC0,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC8F0,
+    D_xk4_800EBEA8,
+    19,
+};
+
+unk_800D7AB4 D_xk4_800EC5A8 = {
+    D_xk4_800EBF28,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC570,
+    D_xk4_800EBF10,
+    18,
+};
+
+unk_800D7AB4 D_xk4_800EC5E0 = {
+    D_xk4_800EBF78,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC5A8,
+    D_xk4_800EBF68,
+    17,
+};
+
+unk_800D7AB4 D_xk4_800EC618 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 543.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC5E0,
+    NULL,
+    NULL,
+    NULL,
+    16,
+};
+
+unk_800D7AB4 D_xk4_800EC650 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 843.0f, 0.0f, 0.0f },
+    { 0xFE5C, 0x00B6, 0xC906 },
+    &D_xk4_800EC5A8,
+    &D_xk4_800EC618,
+    NULL,
+    NULL,
+    15,
+};
+
+unk_800D7AB4 D_xk4_800EC688 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 631.0f, 0.0f, 0.0f },
+    { 0, 0, 0x1CFF },
+    &D_xk4_800EC570,
+    &D_xk4_800EC650,
+    NULL,
+    NULL,
+    14,
+};
+
+unk_800D7AB4 D_xk4_800EC6C0 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0xFFB9, 0x00A5, 0xAD43 },
+    NULL,
+    &D_xk4_800EC688,
+    NULL,
+    NULL,
+    13,
+};
+
+unk_800D7AB4 D_xk4_800EC6F8 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 254.0f, -296.0f, 37.0f },
+    { 0, 0x2A67, 0x407A },
+    &D_xk4_800EC538,
+    &D_xk4_800EC6C0,
+    NULL,
+    NULL,
+    12,
+};
+
+unk_800D7AB4 D_xk4_800EC730 = {
+    D_xk4_800EBFA8,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC8F0,
+    D_xk4_800EBF90,
+    11,
+};
+
+unk_800D7AB4 D_xk4_800EC768 = {
+    D_xk4_800EC010,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC730,
+    D_xk4_800EBFF8,
+    10,
+};
+
+unk_800D7AB4 D_xk4_800EC7A0 = {
+    D_xk4_800EC060,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    NULL,
+    &D_xk4_800EC768,
+    D_xk4_800EC050,
+    9,
+};
+
+unk_800D7AB4 D_xk4_800EC7D8 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 543.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC7A0,
+    NULL,
+    NULL,
+    NULL,
+    8,
+};
+
+unk_800D7AB4 D_xk4_800EC810 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 843.0f, 0.0f, 0.0f },
+    { 0xFF94, 0xFF6C, 0xC2E2 },
+    &D_xk4_800EC768,
+    &D_xk4_800EC7D8,
+    NULL,
+    NULL,
+    7,
+};
+
+unk_800D7AB4 D_xk4_800EC848 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 631.0f, 0.0f, 0.0f },
+    { 0, 0, 0x0037 },
+    &D_xk4_800EC730,
+    &D_xk4_800EC810,
+    NULL,
+    NULL,
+    6,
+};
+
+unk_800D7AB4 D_xk4_800EC880 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0x0002, 0xFCA1, 0xBE6D },
+    NULL,
+    &D_xk4_800EC848,
+    NULL,
+    NULL,
+    5,
+};
+
+unk_800D7AB4 D_xk4_800EC8B8 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 247.0f, 288.0f, 37.0f },
+    { 0x7E29, 0x2D3D, 0xBCCD },
+    &D_xk4_800EC6F8,
+    &D_xk4_800EC880,
+    NULL,
+    NULL,
+    4,
+};
+
+unk_800D7AB4 D_xk4_800EC8F0 = {
+    D_xk4_800EC078,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC8B8,
+    NULL,
+    NULL,
+    NULL,
+    3,
+};
+
+unk_800D7AB4 D_xk4_800EC928 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 379.0f, 0.0f, 0.0f },
+    { 0, 0, 0 },
+    &D_xk4_800EC8F0,
+    NULL,
+    NULL,
+    NULL,
+    2,
+};
+
+unk_800D7AB4 D_xk4_800EC960 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 0.0f, 0.0f, 0.0f },
+    { 0, 0, 0xBF86 },
+    NULL,
+    &D_xk4_800EC928,
+    NULL,
+    NULL,
+    1,
+};
+
+unk_800D7AB4 D_xk4_800EC998 = {
+    NULL,
+    { 1.0f, 1.0f, 1.0f },
+    { 843.0f, -279.0f, 0.0f },
+    { 0, 0, 0 },
+    NULL,
+    &D_xk4_800EC960,
+    NULL,
+    NULL,
+    0,
+};
+
+unk_800D7AB4* D_xk4_800EC9D0[] = {
+    &D_xk4_800EC998,
+    &D_xk4_800EC960,
+    &D_xk4_800EC928,
+    &D_xk4_800EC8F0,
+    &D_xk4_800EC8B8,
+    &D_xk4_800EC880,
+    &D_xk4_800EC848,
+    &D_xk4_800EC810,
+    &D_xk4_800EC7D8,
+    &D_xk4_800EC7A0,
+    &D_xk4_800EC768,
+    &D_xk4_800EC730,
+    &D_xk4_800EC6F8,
+    &D_xk4_800EC6C0,
+    &D_xk4_800EC688,
+    &D_xk4_800EC650,
+    &D_xk4_800EC618,
+    &D_xk4_800EC5E0,
+    &D_xk4_800EC5A8,
+    &D_xk4_800EC570,
+    &D_xk4_800EC538,
+    &D_xk4_800EC500,
+    &D_xk4_800EC4C8,
+    &D_xk4_800EC490,
+    &D_xk4_800EC458,
+    &D_xk4_800EC420,
+    &D_xk4_800EC3E8,
+    &D_xk4_800EC3B0,
+    &D_xk4_800EC378,
+    &D_xk4_800EC340,
+    &D_xk4_800EC308,
+    &D_xk4_800EC2D0,
+    &D_xk4_800EC298,
+    &D_xk4_800EC260,
+    &D_xk4_800EC228,
+    &D_xk4_800EC1F0,
+    &D_xk4_800EC1B8,
+    &D_xk4_800EC180,
+    &D_xk4_800EC148,
+    &D_xk4_800EC110,
+    &D_xk4_800EC0D8,
+    &D_xk4_800EC0A0,
+};
+
+#include "src/assets/overlays/ovl_xk4/ending_dd_congratulations/ending_dd_congratulations.c"
 
 f32 func_xk4_800D6D90(f32 arg0) {
     s32 i;
@@ -19,17 +682,13 @@ f32 func_xk4_800D6D90(f32 arg0) {
     return var_fv1;
 }
 
-extern f32 D_800F1AE0[];
-extern f32 D_xk4_800F2AE0[];
-extern f32* D_xk4_800F6AE0;
-
 void func_xk4_800D6F38(void) {
     s32 i;
 
     for (i = 0; i < 0x1400; i++) {
         D_800F1AE0[i] = func_xk4_800D6D90(2.0f * (((f32)i / 4096) * 3.1415927f));
     }
-    D_xk4_800F6AE0 = D_xk4_800F2AE0;
+    D_xk4_800F6AE0 = &D_800F1AE0[0x400];
 }
 
 void func_xk4_800D6FD0(Mtx* arg0, MtxF* arg1) {
@@ -128,8 +787,6 @@ void func_xk4_800D74A4(MtxF* arg0, f32 arg1, f32 arg2, f32 arg3) {
     arg0->m[3][3] = 1.0f;
 }
 
-extern s32 D_xk4_800F6AF0[];
-
 s32 func_xk4_800D7504(s32 arg0, s32 arg1) {
     D_xk4_800F6AF0[arg0] = arg1;
     return arg1;
@@ -168,7 +825,7 @@ Gfx* func_xk4_800D7530(Gfx* gfx, FrameBuffer* arg1, s32 arg2, s32 arg3, s32 arg4
 
 extern u32 gSegments[];
 
-intptr_t func_xk4_800D7860(uintptr_t segmentedAddr) {
+intptr_t func_xk4_SegmentedToVirtual(uintptr_t segmentedAddr) {
     return PHYSICAL_TO_VIRTUAL(gSegments[SEGMENT_NUMBER(segmentedAddr)] + SEGMENT_OFFSET(segmentedAddr));
 }
 
@@ -178,8 +835,8 @@ void func_xk4_800D7894(s32* arg0, s32 arg1) {
     s16 temp_a0;
 
     sp1C = arg0[0];
-    temp = (s32*)func_xk4_800D7860(arg0[3]);
-    temp_a0 = *(s16*)func_xk4_800D7860(temp[sp1C]);
+    temp = (s32*)func_xk4_SegmentedToVirtual(arg0[3]);
+    temp_a0 = *(s16*)func_xk4_SegmentedToVirtual(temp[sp1C]);
 
     arg0[1] += arg1;
     if (arg0[1] >= temp_a0) {
@@ -241,26 +898,6 @@ void func_xk4_800D7918(MtxF* arg0, s16 arg1, s16 arg2, s16 arg3, f32 arg4, f32 a
 void func_xk4_800D7AAC(void) {
 }
 
-extern s16 D_xk4_800F6B30;
-extern s32(*D_xk4_800F6B34)[6];
-extern s32(*D_xk4_800F6B38)[6];
-extern s32(*D_xk4_800F6B3C)[6];
-extern f32* D_xk4_800F6B40;
-extern s16* D_xk4_800F6B44;
-extern s16* D_xk4_800F6B48;
-
-typedef struct unk_800D7AB4 {
-    Gfx* unk_00;
-    Vec3f unk_04;
-    Vec3f unk_10;
-    Vec3s unk_1C;
-    s32 unk_24;
-    s32 unk_28;
-    void* unk_2C;
-    Gfx* unk_30;
-    s16 unk_34;
-} unk_800D7AB4;
-
 void func_xk4_800D7AB4(unk_800D7AB4* arg0, s32 arg1) {
     s32 temp_a2;
     s32 temp_a3;
@@ -270,7 +907,7 @@ void func_xk4_800D7AB4(unk_800D7AB4* arg0, s32 arg1) {
     s32 temp_v1;
     s32* temp_v0;
 
-    temp_v0 = &D_xk4_800F6B34[D_xk4_800F6B30];
+    temp_v0 = &D_xk4_800F6B34[D_xk4_800F6B30 * 6];
     temp_v1 = *temp_v0++;
     temp_a2 = *temp_v0++;
     temp_a3 = *temp_v0++;
@@ -293,7 +930,7 @@ void func_xk4_800D7AB4(unk_800D7AB4* arg0, s32 arg1) {
     } else {
         arg0->unk_04.z = D_xk4_800F6B40[temp_t2 + temp_t1 - 1];
     }
-    temp_v0 = &D_xk4_800F6B38[D_xk4_800F6B30];
+    temp_v0 = &D_xk4_800F6B38[D_xk4_800F6B30 * 6];
     temp_v1 = *temp_v0++;
     temp_a2 = *temp_v0++;
     temp_a3 = *temp_v0++;
@@ -316,7 +953,7 @@ void func_xk4_800D7AB4(unk_800D7AB4* arg0, s32 arg1) {
     } else {
         arg0->unk_1C.z = D_xk4_800F6B44[temp_t2 + temp_t1 - 1];
     }
-    temp_v0 = &D_xk4_800F6B3C[D_xk4_800F6B30];
+    temp_v0 = &D_xk4_800F6B3C[D_xk4_800F6B30 * 6];
     temp_v1 = *temp_v0++;
     temp_a2 = *temp_v0++;
     temp_a3 = *temp_v0++;
@@ -347,10 +984,7 @@ void func_xk4_800D7E58 (void) {
 void func_xk4_800D7E60 (void) {
 }
 
-extern Mtx* D_xk4_800F6B4C;
-extern Gfx* D_xk4_800F6AE4;
-
-void func_xk4_800D7E68(s32 arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
+void func_xk4_800D7E68(unk_800D7AB4* arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
     unk_800D7AB4* temp_v0;
     MtxF sp104;
     MtxF spC4;
@@ -359,9 +993,9 @@ void func_xk4_800D7E68(s32 arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
     Vec3f sp74;
 
     while (arg0 != 0) {
-        temp_v0 = (unk_800D7AB4*)func_xk4_800D7860(arg0);
+        temp_v0 = (unk_800D7AB4*)func_xk4_SegmentedToVirtual(arg0);
         if ((temp_v0->unk_2C != NULL) && (temp_v0->unk_30 != NULL)) {
-            temp_s3 = ((unk_800D7AB4*)func_xk4_800D7860(temp_v0->unk_2C))->unk_34;
+            temp_s3 = ((unk_800D7AB4*)func_xk4_SegmentedToVirtual(temp_v0->unk_2C))->unk_34;
             
             gSPMatrix(D_xk4_800F6AE4++, &D_xk4_800F6B4C[temp_s3], G_MTX_PUSH | G_MTX_MUL | G_MTX_MODELVIEW);
 
@@ -395,43 +1029,31 @@ void func_xk4_800D7E68(s32 arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
     }
 }
 
-typedef struct unk_800D80E8 {
-    s8 unk_00[0x4];
-    s32 unk_04;
-    s32 unk_08;
-    s32 unk_0C;
-    s32 unk_10;
-    s32 unk_14;
-    s32 unk_18;
-} unk_800D80E8;
-
-extern Vec3f D_xk4_800F1A7C;
 extern GfxPool* gGfxPool;
 
-void func_xk4_800D80E8(s32 arg0, s32 arg1, s32 arg2) {
+UNUSED s32 D_xk4_800F1A78 = 0;
+Vec3f D_xk4_800F1A7C = { 1.0f, 1.0f, 1.0f };
+
+void func_xk4_800D80E8(unk_800D7AB4** arg0, unk_800D80E8* arg1, s32 arg2) {
     unk_800D80E8* temp_s0;
-    s32* sp70;
+    unk_800D7AB4** sp70;
     MtxF sp30;
     Vec3f sp24;
 
-    temp_s0 = func_xk4_800D7860(arg1);
-    sp70 = func_xk4_800D7860(arg0);
+    temp_s0 = func_xk4_SegmentedToVirtual(arg1);
+    sp70 = func_xk4_SegmentedToVirtual(arg0);
     sp24 = D_xk4_800F1A7C;
     D_xk4_800F6B30 = 0;
-    D_xk4_800F6B34 = func_xk4_800D7860(temp_s0->unk_08);
-    D_xk4_800F6B38 = func_xk4_800D7860(temp_s0->unk_10);
-    D_xk4_800F6B3C = func_xk4_800D7860(temp_s0->unk_18);
-    D_xk4_800F6B40 = func_xk4_800D7860(temp_s0->unk_04);
-    D_xk4_800F6B44 = func_xk4_800D7860(temp_s0->unk_0C);
-    D_xk4_800F6B48 = func_xk4_800D7860(temp_s0->unk_14);
+    D_xk4_800F6B34 = func_xk4_SegmentedToVirtual(temp_s0->unk_08);
+    D_xk4_800F6B38 = func_xk4_SegmentedToVirtual(temp_s0->unk_10);
+    D_xk4_800F6B3C = func_xk4_SegmentedToVirtual(temp_s0->unk_18);
+    D_xk4_800F6B40 = func_xk4_SegmentedToVirtual(temp_s0->unk_04);
+    D_xk4_800F6B44 = func_xk4_SegmentedToVirtual(temp_s0->unk_0C);
+    D_xk4_800F6B48 = func_xk4_SegmentedToVirtual(temp_s0->unk_14);
     D_xk4_800F6B4C = gGfxPool->unk_32308;
     func_xk4_800D7454(&sp30);
     func_xk4_800D7E68(*sp70, &sp30, &sp24, arg2);
 }
-
-#ifdef IMPORT_DATA
-extern s32 D_xk4_800DA22C[];
-extern s32 D_xk4_800EC9D0[];
 
 void func_xk4_800D81F4(Gfx** gfxP) {
     static s32 D_xk4_800F1A88 = 0;
@@ -439,9 +1061,6 @@ void func_xk4_800D81F4(Gfx** gfxP) {
     D_xk4_800F6AE4 = *gfxP;
     D_xk4_800F1A88 = (D_xk4_800F1A88 + 1) % 40;
 
-    func_xk4_800D80E8(D_xk4_800EC9D0, D_xk4_800DA22C, D_xk4_800F1A88);
+    func_xk4_800D80E8(D_xk4_800EC9D0, &D_xk4_800DA22C, D_xk4_800F1A88);
     *gfxP = D_xk4_800F6AE4;
 }
-#else
-#pragma GLOBAL_ASM("asm/jp/nonmatchings/overlays/ovl_xk4/1E0B00/func_xk4_800D81F4.s")
-#endif

--- a/src/overlays/ovl_xk4/1E0B00.c
+++ b/src/overlays/ovl_xk4/1E0B00.c
@@ -3,7 +3,7 @@
 #include "assets/overlays/ovl_xk4/a1E0B00.h"
 #include "assets/overlays/ovl_xk4/ending_dd_congratulations.h"
 
-#define PHYSICAL_TO_VIRTUAL(x) (((uintptr_t)x)+0x80000000)
+#define PHYSICAL_TO_VIRTUAL(x) (((uintptr_t) x) + 0x80000000)
 
 typedef struct unk_800D7AB4 {
     Gfx* unk_00;
@@ -99,13 +99,7 @@ UNUSED Mtx D_xk4_800D8A60 = {
 #include "src/assets/overlays/ovl_xk4/ending_dd_animation/ending_dd_animation.c"
 
 unk_800D80E8 D_xk4_800DA22C = {
-    40, 42,
-    D_xk4_800D8AA0,
-    D_xk4_800D963C,
-    D_xk4_800D8AAC,
-    D_xk4_800D9A2C,
-    D_xk4_800D9564,
-    D_xk4_800D9E1C,
+    40, 42, D_xk4_800D8AA0, D_xk4_800D963C, D_xk4_800D8AAC, D_xk4_800D9A2C, D_xk4_800D9564, D_xk4_800D9E1C,
 };
 
 UNUSED s32 D_xk4_800DA248 = 0;
@@ -115,51 +109,22 @@ UNUSED s32 D_xk4_800DA24C = 0;
 
 // TODO: Extract via Torch
 unk_800D7AB4 D_xk4_800EC0A0 = {
-    D_xk4_800EBC00,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC420,
-    D_xk4_800EBBE0,
-    41,
+    D_xk4_800EBC00, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC420,      D_xk4_800EBBE0,       41,
 };
 
 unk_800D7AB4 D_xk4_800EC0D8 = {
-    D_xk4_800EBC68,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC0A0,
-    D_xk4_800EBC48,
-    40,
+    D_xk4_800EBC68, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC0A0,      D_xk4_800EBC48,       40,
 };
 
 unk_800D7AB4 D_xk4_800EC110 = {
-    D_xk4_800EBCB8,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC0D8,
-    D_xk4_800EBCA0,
-    39,
+    D_xk4_800EBCB8, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC0D8,      D_xk4_800EBCA0,       39,
 };
 
 unk_800D7AB4 D_xk4_800EC148 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 450.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC110,
-    NULL,
-    NULL,
-    NULL,
-    38,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 450.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC110, NULL, NULL, NULL, 38,
 };
 
 unk_800D7AB4 D_xk4_800EC180 = {
@@ -187,75 +152,30 @@ unk_800D7AB4 D_xk4_800EC1B8 = {
 };
 
 unk_800D7AB4 D_xk4_800EC1F0 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0xD5F4, 0xA515 },
-    NULL,
-    &D_xk4_800EC1B8,
-    NULL,
-    NULL,
-    35,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0xD5F4, 0xA515 }, NULL, &D_xk4_800EC1B8, NULL, NULL, 35,
 };
 
 unk_800D7AB4 D_xk4_800EC228 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 667.0f, 374.0f, 0.0f },
-    { 0, 0, 0xBFBD },
-    NULL,
-    &D_xk4_800EC1F0,
-    NULL,
-    NULL,
-    34,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 667.0f, 374.0f, 0.0f }, { 0, 0, 0xBFBD }, NULL, &D_xk4_800EC1F0, NULL, NULL, 34,
 };
 
 unk_800D7AB4 D_xk4_800EC260 = {
-    D_xk4_800EBCF8,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC420,
-    D_xk4_800EBCD8,
-    33,
+    D_xk4_800EBCF8, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC420,      D_xk4_800EBCD8,       33,
 };
 
 unk_800D7AB4 D_xk4_800EC298 = {
-    D_xk4_800EBD60,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC260,
-    D_xk4_800EBD40,
-    32,
+    D_xk4_800EBD60, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC260,      D_xk4_800EBD40,       32,
 };
 
 unk_800D7AB4 D_xk4_800EC2D0 = {
-    D_xk4_800EBDB0,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC298,
-    D_xk4_800EBD98,
-    31,
+    D_xk4_800EBDB0, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC298,      D_xk4_800EBD98,       31,
 };
 
 unk_800D7AB4 D_xk4_800EC308 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 450.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC2D0,
-    NULL,
-    NULL,
-    NULL,
-    30,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 450.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC2D0, NULL, NULL, NULL, 30,
 };
 
 unk_800D7AB4 D_xk4_800EC340 = {
@@ -283,15 +203,7 @@ unk_800D7AB4 D_xk4_800EC378 = {
 };
 
 unk_800D7AB4 D_xk4_800EC3B0 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0x8001, 0x8689, 0x235C },
-    NULL,
-    &D_xk4_800EC378,
-    NULL,
-    NULL,
-    27,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0x8001, 0x8689, 0x235C }, NULL, &D_xk4_800EC378, NULL, NULL, 27,
 };
 
 unk_800D7AB4 D_xk4_800EC3E8 = {
@@ -307,39 +219,17 @@ unk_800D7AB4 D_xk4_800EC3E8 = {
 };
 
 unk_800D7AB4 D_xk4_800EC420 = {
-    D_xk4_800EBDE8,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC3E8,
-    NULL,
-    &D_xk4_800EC8F0,
-    D_xk4_800EBDD0,
-    25,
+    D_xk4_800EBDE8, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC3E8,
+    NULL,           &D_xk4_800EC8F0,      D_xk4_800EBDD0,       25,
 };
 
 unk_800D7AB4 D_xk4_800EC458 = {
-    D_xk4_800EBE40,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC420,
-    D_xk4_800EBE28,
-    24,
+    D_xk4_800EBE40, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC420,      D_xk4_800EBE28,       24,
 };
 
 unk_800D7AB4 D_xk4_800EC490 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 522.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC458,
-    NULL,
-    NULL,
-    NULL,
-    23,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 522.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC458, NULL, NULL, NULL, 23,
 };
 
 unk_800D7AB4 D_xk4_800EC4C8 = {
@@ -355,75 +245,30 @@ unk_800D7AB4 D_xk4_800EC4C8 = {
 };
 
 unk_800D7AB4 D_xk4_800EC500 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0xFAEE, 0, 0x42EB },
-    NULL,
-    &D_xk4_800EC4C8,
-    NULL,
-    NULL,
-    21,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0xFAEE, 0, 0x42EB }, NULL, &D_xk4_800EC4C8, NULL, NULL, 21,
 };
 
 unk_800D7AB4 D_xk4_800EC538 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { -93.0f, -1.0f, 0.0f },
-    { 0, 0, 0x407A },
-    NULL,
-    &D_xk4_800EC500,
-    NULL,
-    NULL,
-    20,
+    NULL, { 1.0f, 1.0f, 1.0f }, { -93.0f, -1.0f, 0.0f }, { 0, 0, 0x407A }, NULL, &D_xk4_800EC500, NULL, NULL, 20,
 };
 
 unk_800D7AB4 D_xk4_800EC570 = {
-    D_xk4_800EBEC0,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC8F0,
-    D_xk4_800EBEA8,
-    19,
+    D_xk4_800EBEC0, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC8F0,      D_xk4_800EBEA8,       19,
 };
 
 unk_800D7AB4 D_xk4_800EC5A8 = {
-    D_xk4_800EBF28,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC570,
-    D_xk4_800EBF10,
-    18,
+    D_xk4_800EBF28, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC570,      D_xk4_800EBF10,       18,
 };
 
 unk_800D7AB4 D_xk4_800EC5E0 = {
-    D_xk4_800EBF78,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC5A8,
-    D_xk4_800EBF68,
-    17,
+    D_xk4_800EBF78, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC5A8,      D_xk4_800EBF68,       17,
 };
 
 unk_800D7AB4 D_xk4_800EC618 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 543.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC5E0,
-    NULL,
-    NULL,
-    NULL,
-    16,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 543.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC5E0, NULL, NULL, NULL, 16,
 };
 
 unk_800D7AB4 D_xk4_800EC650 = {
@@ -439,27 +284,12 @@ unk_800D7AB4 D_xk4_800EC650 = {
 };
 
 unk_800D7AB4 D_xk4_800EC688 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 631.0f, 0.0f, 0.0f },
-    { 0, 0, 0x1CFF },
-    &D_xk4_800EC570,
-    &D_xk4_800EC650,
-    NULL,
-    NULL,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 631.0f, 0.0f, 0.0f }, { 0, 0, 0x1CFF }, &D_xk4_800EC570, &D_xk4_800EC650, NULL, NULL,
     14,
 };
 
 unk_800D7AB4 D_xk4_800EC6C0 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0xFFB9, 0x00A5, 0xAD43 },
-    NULL,
-    &D_xk4_800EC688,
-    NULL,
-    NULL,
-    13,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0xFFB9, 0x00A5, 0xAD43 }, NULL, &D_xk4_800EC688, NULL, NULL, 13,
 };
 
 unk_800D7AB4 D_xk4_800EC6F8 = {
@@ -475,51 +305,22 @@ unk_800D7AB4 D_xk4_800EC6F8 = {
 };
 
 unk_800D7AB4 D_xk4_800EC730 = {
-    D_xk4_800EBFA8,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC8F0,
-    D_xk4_800EBF90,
-    11,
+    D_xk4_800EBFA8, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC8F0,      D_xk4_800EBF90,       11,
 };
 
 unk_800D7AB4 D_xk4_800EC768 = {
-    D_xk4_800EC010,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC730,
-    D_xk4_800EBFF8,
-    10,
+    D_xk4_800EC010, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC730,      D_xk4_800EBFF8,       10,
 };
 
 unk_800D7AB4 D_xk4_800EC7A0 = {
-    D_xk4_800EC060,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    NULL,
-    &D_xk4_800EC768,
-    D_xk4_800EC050,
-    9,
+    D_xk4_800EC060, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, NULL,
+    NULL,           &D_xk4_800EC768,      D_xk4_800EC050,       9,
 };
 
 unk_800D7AB4 D_xk4_800EC7D8 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 543.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC7A0,
-    NULL,
-    NULL,
-    NULL,
-    8,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 543.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC7A0, NULL, NULL, NULL, 8,
 };
 
 unk_800D7AB4 D_xk4_800EC810 = {
@@ -535,27 +336,12 @@ unk_800D7AB4 D_xk4_800EC810 = {
 };
 
 unk_800D7AB4 D_xk4_800EC848 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 631.0f, 0.0f, 0.0f },
-    { 0, 0, 0x0037 },
-    &D_xk4_800EC730,
-    &D_xk4_800EC810,
-    NULL,
-    NULL,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 631.0f, 0.0f, 0.0f }, { 0, 0, 0x0037 }, &D_xk4_800EC730, &D_xk4_800EC810, NULL, NULL,
     6,
 };
 
 unk_800D7AB4 D_xk4_800EC880 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0x0002, 0xFCA1, 0xBE6D },
-    NULL,
-    &D_xk4_800EC848,
-    NULL,
-    NULL,
-    5,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0x0002, 0xFCA1, 0xBE6D }, NULL, &D_xk4_800EC848, NULL, NULL, 5,
 };
 
 unk_800D7AB4 D_xk4_800EC8B8 = {
@@ -571,96 +357,29 @@ unk_800D7AB4 D_xk4_800EC8B8 = {
 };
 
 unk_800D7AB4 D_xk4_800EC8F0 = {
-    D_xk4_800EC078,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC8B8,
-    NULL,
-    NULL,
-    NULL,
-    3,
+    D_xk4_800EC078, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC8B8, NULL, NULL, NULL, 3,
 };
 
 unk_800D7AB4 D_xk4_800EC928 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 379.0f, 0.0f, 0.0f },
-    { 0, 0, 0 },
-    &D_xk4_800EC8F0,
-    NULL,
-    NULL,
-    NULL,
-    2,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 379.0f, 0.0f, 0.0f }, { 0, 0, 0 }, &D_xk4_800EC8F0, NULL, NULL, NULL, 2,
 };
 
 unk_800D7AB4 D_xk4_800EC960 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 0.0f, 0.0f, 0.0f },
-    { 0, 0, 0xBF86 },
-    NULL,
-    &D_xk4_800EC928,
-    NULL,
-    NULL,
-    1,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, { 0, 0, 0xBF86 }, NULL, &D_xk4_800EC928, NULL, NULL, 1,
 };
 
 unk_800D7AB4 D_xk4_800EC998 = {
-    NULL,
-    { 1.0f, 1.0f, 1.0f },
-    { 843.0f, -279.0f, 0.0f },
-    { 0, 0, 0 },
-    NULL,
-    &D_xk4_800EC960,
-    NULL,
-    NULL,
-    0,
+    NULL, { 1.0f, 1.0f, 1.0f }, { 843.0f, -279.0f, 0.0f }, { 0, 0, 0 }, NULL, &D_xk4_800EC960, NULL, NULL, 0,
 };
 
 unk_800D7AB4* D_xk4_800EC9D0[] = {
-    &D_xk4_800EC998,
-    &D_xk4_800EC960,
-    &D_xk4_800EC928,
-    &D_xk4_800EC8F0,
-    &D_xk4_800EC8B8,
-    &D_xk4_800EC880,
-    &D_xk4_800EC848,
-    &D_xk4_800EC810,
-    &D_xk4_800EC7D8,
-    &D_xk4_800EC7A0,
-    &D_xk4_800EC768,
-    &D_xk4_800EC730,
-    &D_xk4_800EC6F8,
-    &D_xk4_800EC6C0,
-    &D_xk4_800EC688,
-    &D_xk4_800EC650,
-    &D_xk4_800EC618,
-    &D_xk4_800EC5E0,
-    &D_xk4_800EC5A8,
-    &D_xk4_800EC570,
-    &D_xk4_800EC538,
-    &D_xk4_800EC500,
-    &D_xk4_800EC4C8,
-    &D_xk4_800EC490,
-    &D_xk4_800EC458,
-    &D_xk4_800EC420,
-    &D_xk4_800EC3E8,
-    &D_xk4_800EC3B0,
-    &D_xk4_800EC378,
-    &D_xk4_800EC340,
-    &D_xk4_800EC308,
-    &D_xk4_800EC2D0,
-    &D_xk4_800EC298,
-    &D_xk4_800EC260,
-    &D_xk4_800EC228,
-    &D_xk4_800EC1F0,
-    &D_xk4_800EC1B8,
-    &D_xk4_800EC180,
-    &D_xk4_800EC148,
-    &D_xk4_800EC110,
-    &D_xk4_800EC0D8,
-    &D_xk4_800EC0A0,
+    &D_xk4_800EC998, &D_xk4_800EC960, &D_xk4_800EC928, &D_xk4_800EC8F0, &D_xk4_800EC8B8, &D_xk4_800EC880,
+    &D_xk4_800EC848, &D_xk4_800EC810, &D_xk4_800EC7D8, &D_xk4_800EC7A0, &D_xk4_800EC768, &D_xk4_800EC730,
+    &D_xk4_800EC6F8, &D_xk4_800EC6C0, &D_xk4_800EC688, &D_xk4_800EC650, &D_xk4_800EC618, &D_xk4_800EC5E0,
+    &D_xk4_800EC5A8, &D_xk4_800EC570, &D_xk4_800EC538, &D_xk4_800EC500, &D_xk4_800EC4C8, &D_xk4_800EC490,
+    &D_xk4_800EC458, &D_xk4_800EC420, &D_xk4_800EC3E8, &D_xk4_800EC3B0, &D_xk4_800EC378, &D_xk4_800EC340,
+    &D_xk4_800EC308, &D_xk4_800EC2D0, &D_xk4_800EC298, &D_xk4_800EC260, &D_xk4_800EC228, &D_xk4_800EC1F0,
+    &D_xk4_800EC1B8, &D_xk4_800EC180, &D_xk4_800EC148, &D_xk4_800EC110, &D_xk4_800EC0D8, &D_xk4_800EC0A0,
 };
 
 #include "src/assets/overlays/ovl_xk4/ending_dd_congratulations/ending_dd_congratulations.c"
@@ -686,7 +405,7 @@ void func_xk4_800D6F38(void) {
     s32 i;
 
     for (i = 0; i < 0x1400; i++) {
-        D_800F1AE0[i] = func_xk4_800D6D90(2.0f * (((f32)i / 4096) * 3.1415927f));
+        D_800F1AE0[i] = func_xk4_800D6D90(2.0f * (((f32) i / 4096) * 3.1415927f));
     }
     D_xk4_800F6AE0 = &D_800F1AE0[0x400];
 }
@@ -748,15 +467,18 @@ void func_xk4_800D71DC(MtxF* arg0, MtxF* arg1, MtxF* arg2) {
     arg0->m[0][0] = (arg1->m[0][0] * arg2->m[0][0]) + (arg1->m[0][1] * arg2->m[1][0]) + (arg1->m[0][2] * arg2->m[2][0]);
     arg0->m[0][1] = (arg1->m[0][0] * arg2->m[0][1]) + (arg1->m[0][1] * arg2->m[1][1]) + (arg1->m[0][2] * arg2->m[2][1]);
     arg0->m[0][2] = (arg1->m[0][0] * arg2->m[0][2]) + (arg1->m[0][1] * arg2->m[1][2]) + (arg1->m[0][2] * arg2->m[2][2]);
-    arg0->m[0][3] = (arg1->m[0][0] * arg2->m[0][3]) + (arg1->m[0][1] * arg2->m[1][3]) + (arg1->m[0][2] * arg2->m[2][3]) + arg1->m[0][3];
+    arg0->m[0][3] = (arg1->m[0][0] * arg2->m[0][3]) + (arg1->m[0][1] * arg2->m[1][3]) +
+                    (arg1->m[0][2] * arg2->m[2][3]) + arg1->m[0][3];
     arg0->m[1][0] = (arg1->m[1][0] * arg2->m[0][0]) + (arg1->m[1][1] * arg2->m[1][0]) + (arg1->m[1][2] * arg2->m[2][0]);
     arg0->m[1][1] = (arg1->m[1][0] * arg2->m[0][1]) + (arg1->m[1][1] * arg2->m[1][1]) + (arg1->m[1][2] * arg2->m[2][1]);
     arg0->m[1][2] = (arg1->m[1][0] * arg2->m[0][2]) + (arg1->m[1][1] * arg2->m[1][2]) + (arg1->m[1][2] * arg2->m[2][2]);
-    arg0->m[1][3] = (arg1->m[1][0] * arg2->m[0][3]) + (arg1->m[1][1] * arg2->m[1][3]) + (arg1->m[1][2] * arg2->m[2][3]) + arg1->m[1][3];
+    arg0->m[1][3] = (arg1->m[1][0] * arg2->m[0][3]) + (arg1->m[1][1] * arg2->m[1][3]) +
+                    (arg1->m[1][2] * arg2->m[2][3]) + arg1->m[1][3];
     arg0->m[2][0] = (arg1->m[2][0] * arg2->m[0][0]) + (arg1->m[2][1] * arg2->m[1][0]) + (arg1->m[2][2] * arg2->m[2][0]);
     arg0->m[2][1] = (arg1->m[2][0] * arg2->m[0][1]) + (arg1->m[2][1] * arg2->m[1][1]) + (arg1->m[2][2] * arg2->m[2][1]);
     arg0->m[2][2] = (arg1->m[2][0] * arg2->m[0][2]) + (arg1->m[2][1] * arg2->m[1][2]) + (arg1->m[2][2] * arg2->m[2][2]);
-    arg0->m[2][3] = (arg1->m[2][0] * arg2->m[0][3]) + (arg1->m[2][1] * arg2->m[1][3]) + (arg1->m[2][2] * arg2->m[2][3]) + arg1->m[2][3];
+    arg0->m[2][3] = (arg1->m[2][0] * arg2->m[0][3]) + (arg1->m[2][1] * arg2->m[1][3]) +
+                    (arg1->m[2][2] * arg2->m[2][3]) + arg1->m[2][3];
     arg0->m[3][0] = 0.0f;
     arg0->m[3][1] = 0.0f;
     arg0->m[3][2] = 0.0f;
@@ -765,7 +487,8 @@ void func_xk4_800D71DC(MtxF* arg0, MtxF* arg1, MtxF* arg2) {
 
 void func_xk4_800D7454(MtxF* arg0) {
     arg0->m[0][0] = arg0->m[1][1] = arg0->m[2][2] = arg0->m[3][3] = 1.0f;
-    arg0->m[0][1] = arg0->m[0][2] = arg0->m[0][3] = arg0->m[1][0] = arg0->m[1][2] = arg0->m[1][3] = arg0->m[2][0] = arg0->m[2][1] = arg0->m[2][3] = arg0->m[3][0] = arg0->m[3][1] = arg0->m[3][2] = 0.0f;
+    arg0->m[0][1] = arg0->m[0][2] = arg0->m[0][3] = arg0->m[1][0] = arg0->m[1][2] = arg0->m[1][3] = arg0->m[2][0] =
+        arg0->m[2][1] = arg0->m[2][3] = arg0->m[3][0] = arg0->m[3][1] = arg0->m[3][2] = 0.0f;
 }
 
 void func_xk4_800D74A4(MtxF* arg0, f32 arg1, f32 arg2, f32 arg3) {
@@ -835,8 +558,8 @@ void func_xk4_800D7894(s32* arg0, s32 arg1) {
     s16 temp_a0;
 
     sp1C = arg0[0];
-    temp = (s32*)func_xk4_SegmentedToVirtual(arg0[3]);
-    temp_a0 = *(s16*)func_xk4_SegmentedToVirtual(temp[sp1C]);
+    temp = (s32*) func_xk4_SegmentedToVirtual(arg0[3]);
+    temp_a0 = *(s16*) func_xk4_SegmentedToVirtual(temp[sp1C]);
 
     arg0[1] += arg1;
     if (arg0[1] >= temp_a0) {
@@ -978,10 +701,10 @@ void func_xk4_800D7AB4(unk_800D7AB4* arg0, s32 arg1) {
     }
 }
 
-void func_xk4_800D7E58 (void) {
+void func_xk4_800D7E58(void) {
 }
 
-void func_xk4_800D7E60 (void) {
+void func_xk4_800D7E60(void) {
 }
 
 void func_xk4_800D7E68(unk_800D7AB4* arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
@@ -993,10 +716,10 @@ void func_xk4_800D7E68(unk_800D7AB4* arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
     Vec3f sp74;
 
     while (arg0 != 0) {
-        temp_v0 = (unk_800D7AB4*)func_xk4_SegmentedToVirtual(arg0);
+        temp_v0 = (unk_800D7AB4*) func_xk4_SegmentedToVirtual(arg0);
         if ((temp_v0->unk_2C != NULL) && (temp_v0->unk_30 != NULL)) {
-            temp_s3 = ((unk_800D7AB4*)func_xk4_SegmentedToVirtual(temp_v0->unk_2C))->unk_34;
-            
+            temp_s3 = ((unk_800D7AB4*) func_xk4_SegmentedToVirtual(temp_v0->unk_2C))->unk_34;
+
             gSPMatrix(D_xk4_800F6AE4++, &D_xk4_800F6B4C[temp_s3], G_MTX_PUSH | G_MTX_MUL | G_MTX_MODELVIEW);
 
             gSPDisplayList(D_xk4_800F6AE4++, temp_v0->unk_30);
@@ -1004,7 +727,8 @@ void func_xk4_800D7E68(unk_800D7AB4* arg0, MtxF* arg1, Vec3f* arg2, s32 arg3) {
         }
         temp_s3 = temp_v0->unk_34;
         func_xk4_800D7AB4(temp_v0, arg3);
-        func_xk4_800D7918(&sp104, temp_v0->unk_1C.x, temp_v0->unk_1C.y, temp_v0->unk_1C.z, temp_v0->unk_10.x * arg2->x, temp_v0->unk_10.y * arg2->y, temp_v0->unk_10.z * arg2->z);
+        func_xk4_800D7918(&sp104, temp_v0->unk_1C.x, temp_v0->unk_1C.y, temp_v0->unk_1C.z, temp_v0->unk_10.x * arg2->x,
+                          temp_v0->unk_10.y * arg2->y, temp_v0->unk_10.z * arg2->z);
         sp74.x = arg2->x * temp_v0->unk_04.x;
         sp74.y = arg2->y * temp_v0->unk_04.y;
         sp74.z = arg2->z * temp_v0->unk_04.z;

--- a/src/overlays/ovl_xk4/1E1FD0.c
+++ b/src/overlays/ovl_xk4/1E1FD0.c
@@ -1,0 +1,128 @@
+#include "global.h"
+#include "fzx_assets.h"
+
+Lights1 D_xk4_800F1A90 = gdSPDefLights1(50, 50, 30, 255, 200, 160, 0, 84, 84);
+
+Vp D_xk4_800F1AA8 = {
+    640, 480, 511, 0,
+    640, 480, 511, 0,
+};
+
+extern s32 D_8076C77C;
+extern s16 D_8076C7A8;
+
+void func_xk4_800D8260(void) {
+    func_807419F0(0x14);
+    func_80741A0C(0x14);
+    func_xk4_800D6F38();
+    D_8076C77C = 2;
+    D_8076C7A8 = 3;
+}
+
+extern s32 D_800BEE14;
+extern s32 D_8076C77C;
+
+extern GfxPool D_8024E260[];
+extern s32 D_8079A35C;
+extern s32 gGameMode;
+extern s32 D_8076C7C0;
+extern u16 gInputButtonPressed;
+extern GfxPool* gGfxPool;
+
+s32 func_xk4_800D82A4(void) {
+    gGfxPool = &D_8024E260[D_8079A35C];
+    if (D_800BEE14 != 0) {
+        return gGameMode;
+    }
+    Controller_SetGlobalInputs(&gSharedController);
+    if (gInputButtonPressed & BTN_START) {
+        func_80741B84();
+        D_8076C77C = 1;
+        return D_8076C7C0;
+    }
+
+    return gGameMode;
+}
+
+extern Gfx D_8076CAF8[];
+extern u8 D_xk4_800ECA78[];
+extern GfxPool D_1000000;
+extern FrameBuffer* gFrameBuffers[];
+extern s32 D_8079A364;
+
+Gfx* func_xk4_800D8348(Gfx* gfx) {
+    static s32 D_xk4_800F1AB8 = 4800;
+    static s32 D_xk4_800F1ABC = -550;
+    static s32 D_xk4_800F1AC0 = 0;
+    s32 temp_lo;
+    s32 i;
+    u16 spFE;
+    s32 pad[2];
+
+    gSPDisplayList(gfx++, D_3000338);
+    gSPDisplayList(gfx++, D_8076CAF8);
+
+    gfx = func_xk4_800D7530(gfx, gFrameBuffers[D_8079A364], 0, 0, 0x60, 0, 0, 0);
+    gSPDisplayList(gfx++, D_8014940);
+
+    for (i = 0; i < 64; i++) {
+        gDPLoadTextureBlock(gfx++, D_xk4_800ECA78 + i * SCREEN_WIDTH, G_IM_FMT_RGBA, G_IM_SIZ_16b, 160, 1, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+
+        gSPTextureRectangle(gfx++, 24 << 2, (i + 32) << 2, 184 << 2, ((i + 1) + 32) << 2, 0, 0, 0, 1 << 10, 1 << 10);
+    }
+
+    if (SQ(gControllers[gPlayerControlPorts[0]].stickX) >= 0x65) {
+        D_xk4_800F1AC0 += gControllers[gPlayerControlPorts[0]].stickX / 10;
+    }
+    if (gControllers[gPlayerControlPorts[0]].buttonCurrent & BTN_Z) {
+        D_xk4_800F1AC0 = 0;
+    }
+    temp_lo = (s32) (D_xk4_800F1AC0 << 0xC) / 360;
+    func_806F7FCC(gGfxPool->unk_36628, NULL, 1.0f, 1.0f, 1.0f, SIN(temp_lo), 0.0f, COS(temp_lo), 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+
+    if (gControllers[gPlayerControlPorts[0]].buttonCurrent & BTN_L) {
+        D_xk4_800F1AB8 += 50;
+    }
+    if (gControllers[gPlayerControlPorts[0]].buttonCurrent & BTN_R) {
+        D_xk4_800F1AB8 -= 50;
+    }
+    if (D_xk4_800F1AB8 < 1600) {
+        D_xk4_800F1AB8 = 1600;
+    }
+    if (D_xk4_800F1AB8 > 4800) {
+        D_xk4_800F1AB8 = 4800;
+    }
+
+    D_xk4_800F1ABC = ((4800 - D_xk4_800F1AB8) / 3) - 550;
+
+    gSPViewport(gfx++, &D_xk4_800F1AA8);
+
+    func_806F9384(gGfxPool->unk_1A008, NULL, 60.0f, 64.0f, 8192.0f, 320.0f, -80.0f, 240.0f, 0.0f, &spFE);
+
+    gSPPerspNormalize(gfx++, spFE);
+
+    gSPMatrix(gfx++, D_1000000.unk_1A008, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+
+    func_806F8FE0(gGfxPool->unk_1A108, NULL, 500.0f, D_xk4_800F1ABC, D_xk4_800F1AB8, 500.0f, D_xk4_800F1ABC, 0, 0, 1, 0);
+
+    gSPMatrix(gfx++, D_1000000.unk_1A108, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
+    gSPMatrix(gfx++, gGfxPool->unk_36628, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+    gSPDisplayList(gfx++, D_3000400);
+
+    gSPTexture(gfx++, 0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON);
+    
+    gSPNumLights(gfx++, NUMLIGHTS_1);
+    gSPSetLights1(gfx++, D_xk4_800F1A90);
+
+    gSPClipRatio(gfx++, FRUSTRATIO_4);
+    gDPSetTextureFilter(gfx++, G_TF_BILERP);
+    gDPSetCombineMode(gfx++, G_CC_MODULATEIA, G_CC_MODULATEIA);
+    gDPSetRenderMode(gfx++, G_RM_AA_ZB_OPA_SURF, G_RM_AA_ZB_OPA_SURF2);
+    gDPPipelineMode(gfx++, G_PM_1PRIMITIVE);
+
+    func_xk4_800D81F4(&gfx);
+    return gfx;
+}

--- a/src/overlays/ovl_xk4/1E1FD0.c
+++ b/src/overlays/ovl_xk4/1E1FD0.c
@@ -4,8 +4,7 @@
 Lights1 D_xk4_800F1A90 = gdSPDefLights1(50, 50, 30, 255, 200, 160, 0, 84, 84);
 
 Vp D_xk4_800F1AA8 = {
-    640, 480, 511, 0,
-    640, 480, 511, 0,
+    640, 480, 511, 0, 640, 480, 511, 0,
 };
 
 extern s32 D_8076C77C;
@@ -66,8 +65,9 @@ Gfx* func_xk4_800D8348(Gfx* gfx) {
     gSPDisplayList(gfx++, D_8014940);
 
     for (i = 0; i < 64; i++) {
-        gDPLoadTextureBlock(gfx++, D_xk4_800ECA78 + i * SCREEN_WIDTH, G_IM_FMT_RGBA, G_IM_SIZ_16b, 160, 1, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+        gDPLoadTextureBlock(gfx++, D_xk4_800ECA78 + i * SCREEN_WIDTH, G_IM_FMT_RGBA, G_IM_SIZ_16b, 160, 1, 0,
+                            G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
+                            G_TX_NOLOD);
 
         gSPTextureRectangle(gfx++, 24 << 2, (i + 32) << 2, 184 << 2, ((i + 1) + 32) << 2, 0, 0, 0, 1 << 10, 1 << 10);
     }
@@ -79,7 +79,8 @@ Gfx* func_xk4_800D8348(Gfx* gfx) {
         D_xk4_800F1AC0 = 0;
     }
     temp_lo = (s32) (D_xk4_800F1AC0 << 0xC) / 360;
-    func_806F7FCC(gGfxPool->unk_36628, NULL, 1.0f, 1.0f, 1.0f, SIN(temp_lo), 0.0f, COS(temp_lo), 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    func_806F7FCC(gGfxPool->unk_36628, NULL, 1.0f, 1.0f, 1.0f, SIN(temp_lo), 0.0f, COS(temp_lo), 0.0f, 1.0f, 0.0f, 0.0f,
+                  0.0f, 0.0f);
 
     if (gControllers[gPlayerControlPorts[0]].buttonCurrent & BTN_L) {
         D_xk4_800F1AB8 += 50;
@@ -104,7 +105,8 @@ Gfx* func_xk4_800D8348(Gfx* gfx) {
 
     gSPMatrix(gfx++, D_1000000.unk_1A008, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 
-    func_806F8FE0(gGfxPool->unk_1A108, NULL, 500.0f, D_xk4_800F1ABC, D_xk4_800F1AB8, 500.0f, D_xk4_800F1ABC, 0, 0, 1, 0);
+    func_806F8FE0(gGfxPool->unk_1A108, NULL, 500.0f, D_xk4_800F1ABC, D_xk4_800F1AB8, 500.0f, D_xk4_800F1ABC, 0, 0, 1,
+                  0);
 
     gSPMatrix(gfx++, D_1000000.unk_1A108, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
 
@@ -113,7 +115,7 @@ Gfx* func_xk4_800D8348(Gfx* gfx) {
     gSPDisplayList(gfx++, D_3000400);
 
     gSPTexture(gfx++, 0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON);
-    
+
     gSPNumLights(gfx++, NUMLIGHTS_1);
     gSPSetLights1(gfx++, D_xk4_800F1A90);
 

--- a/yamls/jp/overlays.yaml
+++ b/yamls/jp/overlays.yaml
@@ -330,9 +330,9 @@
     subsegments:
       - [0x1E0B00, c]
       - [0x1E1FD0, c]
-      - [0x1E27D0, data, 1E0B00]
+      - [0x1E27D0, .data, 1E0B00]
       - [0x1FB800, .data, 1E1FD0]
       - [0x1FB840, .rodata, 1E1FD0]
-      - { type: bss, vram: 0x800F1AE0 }
+      - { type: .bss, vram: 0x800F1AE0, name: 1E0B00 }
 
   - [0x1FB850]

--- a/yamls/jp/overlays.yaml
+++ b/yamls/jp/overlays.yaml
@@ -329,8 +329,10 @@
     symbol_name_format: xk4_$VRAM
     subsegments:
       - [0x1E0B00, c]
-      - [0x1E27D0, data]
-      - [0x1FB840, .rodata, 1E0B00]
+      - [0x1E1FD0, c]
+      - [0x1E27D0, data, 1E0B00]
+      - [0x1FB800, .data, 1E1FD0]
+      - [0x1FB840, .rodata, 1E1FD0]
       - { type: bss, vram: 0x800F1AE0 }
 
   - [0x1FB850]


### PR DESCRIPTION
This overlay is for that short congratulations screen before the staff credits start (w/ the dancing mr ead). It creates a skeleton for mr ead and plays an animation for dancing. They appear to have started making it all self contained within the overlays, introducing their own sin table and segment table, but then they opt to use the global variants (gSinTable, gSegments), leaving these initialisation and setup functions unused (although still using the overlays own SegmentedToVirtual function)

Not sure I fully understand how the SegmentedToVirtual bit can actually work, but it does follow patterns from other games so think it should all be correct

I need to make a factory for all the skeleton limbs and animations but have extracted them now regardless